### PR TITLE
ExecuteOn return false if object is not modified

### DIFF
--- a/include/redis_command.h
+++ b/include/redis_command.h
@@ -6394,11 +6394,15 @@ public:
  */
 struct StoreListCommand : public RedisCommand
 {
-    StoreListCommand() = default;
+    StoreListCommand()
+    {
+        result_.err_code_ = RD_OK;
+    };
     explicit StoreListCommand(std::vector<EloqString> elements)
         : elements_(std::move(elements))
     {
         SetVolatile();
+        result_.err_code_ = RD_OK;
     }
 
     StoreListCommand(const StoreListCommand &rhs);
@@ -6432,7 +6436,8 @@ struct StoreListCommand : public RedisCommand
 
     bool ProceedOnNonExistentObject() const override
     {
-        return true;
+        // If nothing to store and the object was empty, cannot proceed.
+        return !elements_.empty();
     }
 
     bool ProceedOnExistentObject() const override
@@ -6447,7 +6452,7 @@ struct StoreListCommand : public RedisCommand
 
     bool IgnoreOldValue() const override
     {
-        return IsOverwrite();
+        return !elements_.empty();
     }
 
     txservice::ExecResult ExecuteOn(const txservice::TxObject &object) override;

--- a/include/redis_hash_object.h
+++ b/include/redis_hash_object.h
@@ -210,7 +210,7 @@ public:
     void Execute(HGetCommand &) const;
     void Execute(HLenCommand &) const;
     void Execute(HStrLenCommand &) const;
-    void Execute(HDelCommand &) const;
+    bool Execute(HDelCommand &) const;
     void Execute(HExistsCommand &) const;
     void Execute(HGetAllCommand &) const;
     bool Execute(HIncrByCommand &) const;

--- a/include/redis_list_object.h
+++ b/include/redis_list_object.h
@@ -186,7 +186,7 @@ public:
     bool Execute(LInsertCommand &cmd) const;
     void Execute(LPosCommand &cmd) const;
     bool Execute(LSetCommand &cmd) const;
-    void Execute(LRemCommand &cmd) const;
+    bool Execute(LRemCommand &cmd) const;
     bool Execute(LPushXCommand &cmd) const;
     bool Execute(RPushXCommand &cmd) const;
     bool Execute(LMovePopCommand &cmd) const;

--- a/include/redis_set_object.h
+++ b/include/redis_set_object.h
@@ -58,12 +58,12 @@ public:
 
     bool Execute(SAddCommand &cmd) const;
     void Execute(SMembersCommand &cmd) const;
-    void Execute(SRemCommand &cmd) const;
+    bool Execute(SRemCommand &cmd) const;
     void Execute(SCardCommand &cmd) const;
     void Execute(SIsMemberCommand &cmd) const;
     void Execute(SMIsMemberCommand &cmd) const;
     void Execute(SRandMemberCommand &cmd) const;
-    void Execute(SPopCommand &cmd) const;
+    bool Execute(SPopCommand &cmd) const;
     void Execute(SScanCommand &cmd) const;
     void Execute(SortableLoadCommand &cmd) const;
     void Execute(SZScanCommand &cmd) const;

--- a/include/redis_zset_object.h
+++ b/include/redis_zset_object.h
@@ -162,21 +162,21 @@ public:
 
     txservice::TxRecord::Uptr AddTTL(uint64_t ttl) override;
 
-    std::pair<int, int> ZAddXX(
+    std::tuple<int, int, bool> ZAddXX(
         std::vector<std::pair<double, EloqString>> &elements, bool ch) const;
-    std::pair<int, int> ZAddNX(
+    std::tuple<int, int, bool> ZAddNX(
         std::vector<std::pair<double, EloqString>> &elements) const;
-    std::pair<int, int> ZAddLT(
+    std::tuple<int, int, bool> ZAddLT(
         std::vector<std::pair<double, EloqString>> &elements,
         bool ch,
         bool xx) const;
-    std::pair<int, int> ZAddGT(
+    std::tuple<int, int, bool> ZAddGT(
         std::vector<std::pair<double, EloqString>> &elements,
         bool ch,
         bool xx) const;
-    std::pair<int, int> ZAdd(
+    std::tuple<int, int, bool> ZAdd(
         std::vector<std::pair<double, EloqString>> &elements, bool ch) const;
-    std::pair<int, EloqString> ZAddIncr(
+    std::tuple<int, EloqString, bool> ZAddIncr(
         std::variant<std::monostate,
                      std::pair<double, EloqString>,
                      std::vector<std::pair<double, EloqString>>> &elements,
@@ -184,11 +184,11 @@ public:
         ZAddCommand::ElementType &type) const;
 
     bool Execute(ZAddCommand &cmd) const;
-    void Execute(ZRemCommand &cmd) const;
-    void Execute(ZRemRangeCommand &cmd) const;
+    bool Execute(ZRemCommand &cmd) const;
+    bool Execute(ZRemRangeCommand &cmd) const;
     void Execute(ZScoreCommand &cmd) const;
     void Execute(ZRangeCommand &cmd) const;
-    void Execute(ZPopCommand &cmd) const;
+    bool Execute(ZPopCommand &cmd) const;
     void Execute(ZLexCountCommand &cmd) const;
     void Execute(ZCountCommand &cmd) const;
     void Execute(ZCardCommand &cmd) const;

--- a/src/redis_hash_object.cpp
+++ b/src/redis_hash_object.cpp
@@ -145,7 +145,7 @@ void RedisHashObject::Execute(EloqKV::HStrLenCommand &cmd) const
     }
 }
 
-void RedisHashObject::Execute(EloqKV::HDelCommand &cmd) const
+bool RedisHashObject::Execute(EloqKV::HDelCommand &cmd) const
 {
     RedisHashResult &hash_result = cmd.result_;
     int cnt = 0;
@@ -153,9 +153,12 @@ void RedisHashObject::Execute(EloqKV::HDelCommand &cmd) const
     {
         cnt += (hash_map_.find(key) != hash_map_.end());
     }
-    if (cnt)
+    if (cnt > 0)
+    {
         hash_result.err_code_ = RD_OK;
+    }
     hash_result.result_ = cnt;
+    return cnt > 0;
 }
 
 bool RedisHashObject::CommitHdel(std::vector<EloqString> &keys)

--- a/src/redis_list_object.cpp
+++ b/src/redis_list_object.cpp
@@ -445,7 +445,7 @@ bool RedisListObject::Execute(LSetCommand &cmd) const
     }
 }
 
-void RedisListObject::Execute(LRemCommand &cmd) const
+bool RedisListObject::Execute(LRemCommand &cmd) const
 {
     RedisListResult &list_result = cmd.result_;
 
@@ -492,6 +492,7 @@ void RedisListObject::Execute(LRemCommand &cmd) const
             }
         }
     }
+    return list_result.ret_ > 0;
 }
 
 bool RedisListObject::Execute(LPushXCommand &cmd) const

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -936,7 +936,7 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
             {
                 LOG(ERROR)
                     << "WAL is enabled but `txlog_service_list` is empty and "
-                       "no built-in log server as `WITH_LOG_SERVICE` is ON, "
+                       "built-in log server initialization failed, "
                        "unable to proceed.";
                 return false;
             }

--- a/src/redis_set_object.cpp
+++ b/src/redis_set_object.cpp
@@ -74,7 +74,7 @@ bool RedisHashSetObject::Execute(SAddCommand &cmd) const
         return false;
     }
 
-    return true;
+    return result.ret_ > 0;
 }
 
 void RedisHashSetObject::Execute(SMembersCommand &cmd) const

--- a/src/redis_set_object.cpp
+++ b/src/redis_set_object.cpp
@@ -90,7 +90,7 @@ void RedisHashSetObject::Execute(SMembersCommand &cmd) const
     }
 }
 
-void RedisHashSetObject::Execute(SRemCommand &cmd) const
+bool RedisHashSetObject::Execute(SRemCommand &cmd) const
 {
     RedisHashSetResult &result = cmd.result_;
     result.err_code_ = RD_OK;
@@ -100,6 +100,7 @@ void RedisHashSetObject::Execute(SRemCommand &cmd) const
     {
         result.ret_ += hash_set_.find(str) == hash_set_.end() ? 0 : 1;
     }
+    return result.ret_ > 0;
 }
 
 void RedisHashSetObject::Execute(SCardCommand &cmd) const
@@ -135,6 +136,8 @@ void RedisHashSetObject::Execute(SRandMemberCommand &cmd) const
     int64_t count = cmd.count_ < 0 ? -cmd.count_ : cmd.count_;
     bool distinct = cmd.count_ >= 0;
     int32_t sz = static_cast<int32_t>(hash_set_.size());
+    // When a set is empty, it is removed. Empty set does not exist.
+    assert(sz > 0);
     if (distinct)
     {
         count = sz < count ? sz : count;
@@ -205,7 +208,7 @@ void RedisHashSetObject::Execute(SRandMemberCommand &cmd) const
     }
 }
 
-void RedisHashSetObject::Execute(SPopCommand &cmd) const
+bool RedisHashSetObject::Execute(SPopCommand &cmd) const
 {
     RedisHashSetResult &result = cmd.result_;
     result.err_code_ = RD_OK;
@@ -281,6 +284,7 @@ void RedisHashSetObject::Execute(SPopCommand &cmd) const
             result.string_list_[miter->second] = hiter->Clone();
         }
     }
+    return !result.string_list_.empty();
 }
 
 // TODO(lzx): Support Cursor and Count.(Batch Scanning)


### PR DESCRIPTION
Fix all the commands that wrongly updates the cce's version when the object is not modified.
Fix SADD with GT option.