### PR TITLE
chore: set base image to ubuntu24.04 and not latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 RUN set -eux; \
     apt update; \


### PR DESCRIPTION
changes:
- Make container builds reproducible to avoid the unknown impact brought by latest
- Add dependabot to auto update ~~base image version~~ and github actions.

we may want to update it to TLS version and not auto update, so i removed it.
