### PR TITLE
Support listen on all interfaces

### DIFF
--- a/concourse/artifact/eloqkv.ini
+++ b/concourse/artifact/eloqkv.ini
@@ -1,5 +1,6 @@
 [local]
 # It is recommended to set the IP to either a private or public IP address
+bind_all=off
 ip=127.0.0.1
 port=6379
 # Checkpoint_interval determine the frequency of flushing dirty records into data store

--- a/include/redis_service.h
+++ b/include/redis_service.h
@@ -96,7 +96,7 @@ namespace EloqKV
 {
 extern int databases;
 extern std::string requirepass;
-extern std::string redis_ip_port;
+extern butil::EndPoint listen_addr;
 extern brpc::Acceptor *server_acceptor;
 
 enum struct HostStatus : uint8_t

--- a/src/redis_server.cpp
+++ b/src/redis_server.cpp
@@ -38,7 +38,7 @@ constexpr char VERSION[] = "0.8.19";
 
 // Global variable defined in redis_service.cpp
 extern brpc::Acceptor *EloqKV::server_acceptor;
-extern std::string EloqKV::redis_ip_port;
+extern butil::EndPoint EloqKV::listen_addr;
 
 void PrintHelloText()
 {
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
     // Notice: redis_service_impl will be deleted in server's destructor.
     server_options.redis_service = redis_service_impl.release();
     server_options.has_builtin_services = false;
-    if (server.Start(redis_ip_port.c_str(), &server_options) != 0)
+    if (server.Start(listen_addr, &server_options) != 0)
     {
         LOG(ERROR) << "Failed to start EloqKV server.";
         redis_service_ptr->Stop();
@@ -104,11 +104,11 @@ int main(int argc, char *argv[])
 
     if (!FLAGS_alsologtostderr)
     {
-        std::cout << "EloqKV Server Started, listening on " << redis_ip_port
-                  << std::endl;
+        std::cout << "EloqKV Server Started, listening on "
+                  << butil::endpoint2str(listen_addr) << std::endl;
     }
-    LOG(INFO) << "==== EloqKV Server Started, listening on " << redis_ip_port
-              << "====";
+    LOG(INFO) << "==== EloqKV Server Started, listening on "
+              << butil::endpoint2str(listen_addr) << "====";
 
     EloqKV::server_acceptor = server.GetAcceptor();
 


### PR DESCRIPTION
Add a boolean option bind_all to support bind on 0.0.0.0. When bind_all is on, EloqKV listens on 0.0.0.0, otherwise listens on local.ip.