### PR TITLE
bug: fix cluster command result

### DIFF
--- a/concourse/scripts/common.sh
+++ b/concourse/scripts/common.sh
@@ -2205,6 +2205,7 @@ function run_eloqkv_cluster_tests() {
         --core_number=2 \
         --enable_wal=false \
         --enable_data_store=true \
+        --ip_port_list=127.0.0.1:6379,127.0.0.1:7379,127.0.0.1:8379 \
         --eloq_data_path="/tmp/redis_server_data_$index" \
         --eloq_dss_peer_node=$dss_server_ip_port \
         --maxclients=1000000 \

--- a/concourse/scripts/common.sh
+++ b/concourse/scripts/common.sh
@@ -67,6 +67,10 @@ function run_tcl_tests()
 {
   local test_to_run=$1
   local is_cluster=${3:-false}
+  local cluster_mode="--tags -needs:cluster_mode"
+  if [[ $is_cluster = "false" ]]; then
+    cluster_mode=""
+  fi
   local fault_inject="--tags -needs:fault_inject"
   if [[ $2 = "Debug" ]]; then
     fault_inject=""
@@ -95,6 +99,7 @@ function run_tcl_tests()
     --tags -needs:support_cmd_later \
     $fault_inject \
     $no_evicted \
+    $cluster_mode \
     --single /unit/mono/"
   local files=$(find ${eloqkv_base_path}/tests/unit/mono -maxdepth 2 -type f)
 

--- a/concourse/scripts/common.sh
+++ b/concourse/scripts/common.sh
@@ -68,7 +68,7 @@ function run_tcl_tests()
   local test_to_run=$1
   local is_cluster=${3:-false}
   local cluster_mode="--tags -needs:cluster_mode"
-  if [[ $is_cluster = "false" ]]; then
+  if [[ $is_cluster = "true" ]]; then
     cluster_mode=""
   fi
   local fault_inject="--tags -needs:fault_inject"

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -10261,6 +10261,20 @@ std::tuple<bool, std::unique_ptr<ClusterCommand>> ParseClusterCommand(
         output->OnError("ERR wrong number of arguments for 'cluster' command");
         return {false, nullptr};
     }
+    if (Sharder::Instance().GetNodeCount() == 1)
+    {
+        if (0 == strcasecmp(args[1].data(), "info") ||
+            0 == strcasecmp(args[1].data(), "nodes"))
+        {
+            output->OnString(
+                "ERR This instance has cluster support disabled\n");
+        }
+        else
+        {
+            output->OnError("ERR This instance has cluster support disabled");
+        }
+        return {false, nullptr};
+    }
     if (0 == strcasecmp(args[1].data(), "info"))
     {
         if (args.size() == 2)

--- a/tests/unit/mono/cluster_cmds.tcl
+++ b/tests/unit/mono/cluster_cmds.tcl
@@ -9,6 +9,6 @@ start_server {tags {"cluster_cmds"}} {
 
        assert_equal 7471 [ r CLUSTER KEYSLOT "\{b\{a\}c\}d" ]
        assert_equal 7471 [ r CLUSTER KEYSLOT "b\{a" ]
-    }
+    } {} {nees:cluster_mode}
 
 }

--- a/tests/unit/mono/cluster_cmds.tcl
+++ b/tests/unit/mono/cluster_cmds.tcl
@@ -9,6 +9,6 @@ start_server {tags {"cluster_cmds"}} {
 
        assert_equal 7471 [ r CLUSTER KEYSLOT "\{b\{a\}c\}d" ]
        assert_equal 7471 [ r CLUSTER KEYSLOT "b\{a" ]
-    } {} {nees:cluster_mode}
+    } {} {needs:cluster_mode}
 
 }


### PR DESCRIPTION
Report an error with `cluster` related commands if `EloqKV` is started in single node mode so that it does not confuse some of the smart clients.