### PR TITLE
add BLPOP debug log

### DIFF
--- a/include/redis_command.h
+++ b/include/redis_command.h
@@ -2873,7 +2873,13 @@ public:
             return false;
         }
 
-        return txservice::LocalCcShards::ClockTs() > ts_expired_;
+        auto clock_ts = txservice::LocalCcShards::ClockTs();
+        if (clock_ts > ts_expired_)
+        {
+            DLOG(INFO) << "BLMPopCommand, expired, ClockTs: " << clock_ts
+                       << ", ts_expired: " << ts_expired_;
+        }
+        return clock_ts > ts_expired_;
     }
 
     uint32_t NumOfFinishBlockCommands() const override

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -4977,6 +4977,7 @@ BLMPopCommand::BLMPopCommand(std::vector<EloqKey> &&v_key,
     // into the related object.
     vct_key_ptrs_.push_back(std::move(vct_key));
     vct_cmd_ptrs_.push_back(std::move(vct_cmd));
+    DLOG(INFO) << "BLMPopCommand, ts_expired: " << ts_expired;
 }
 
 void BLMPopCommand::OutputResult(OutputHandler *reply) const
@@ -11516,6 +11517,11 @@ std::tuple<bool, EloqKey, RPushCommand> ParseRPushCommand(
     {
         output->OnError("ERR wrong number of arguments for 'rpush' command");
         return {false, EloqKey(), RPushCommand()};
+    }
+
+    if ((args[1] == "blist1{t}" || args[1] == "blist2{t}") && args[2] == "foo")
+    {
+        DLOG(INFO) << "rpush : " << args[1] << " " << args[2];
     }
 
     std::vector<EloqString> elements;

--- a/src/redis_list_object.cpp
+++ b/src/redis_list_object.cpp
@@ -641,6 +641,12 @@ void RedisListObject::CommitLSet(int64_t index, EloqString &element)
 
 void RedisListObject::CommitRPush(std::vector<EloqString> &elements)
 {
+    if (list_object_.empty() && elements.size() == 1 &&
+        elements[0].StringView() == "foo")
+    {
+        DLOG(INFO) << "Empty list object CommitRPush foo";
+    }
+
     for (auto &element : elements)
     {
         serialized_length_ += sizeof(uint32_t) + element.Length();


### PR DESCRIPTION
For #109 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Enhanced debug logging around blocking-list pop expiration timing, now emitting timestamps when an item is considered expired.
  - Added constructor-time logging of expiration values to aid troubleshooting.
  - Introduced conditional debug logs for specific list-push scenarios to support targeted diagnostics.
  - Added diagnostic logs during list append operations when inserting certain values.
  - No functional or interface changes; behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->