### PR TITLE
introduce random parameter for load key script

### DIFF
--- a/tests/bulk_load/load_keys.go
+++ b/tests/bulk_load/load_keys.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"crypto/rand"
 	"flag"
 	"fmt"
 	"log"
+	"math/big"
 	"runtime"
 	"strconv"
 	"sync"
@@ -22,6 +24,7 @@ var (
 	startKey  = flag.Int("start_key", 1, "Starting key index")
 	threads   = flag.Int("threads", 1, "Number of worker threads (GOMAXPROCS)")
 	conns     = flag.Int("conns", 1, "Total number of parallel connections/jobs")
+	randomVal = flag.Bool("random", false, "Generate random value data for each request")
 )
 
 var uploaded int64
@@ -34,11 +37,6 @@ func main() {
 	runtime.GOMAXPROCS(*threads)
 
 	fmt.Printf("Launching %d connections for keys %d ~ %d (stride mode)\n", *conns, *startKey, *totalKeys)
-
-	value := make([]byte, *dataSize)
-	for i := range value {
-		value[i] = 'x'
-	}
 
 	done := make(chan struct{})
 	go func() {
@@ -62,7 +60,7 @@ func main() {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
-			doJob(id, value)
+			doJob(id)
 		}(i)
 	}
 	wg.Wait()
@@ -71,15 +69,26 @@ func main() {
 	fmt.Println("All jobs finished")
 }
 
-func doJob(id int, value []byte) {
+func doJob(id int) {
 	ctx := context.Background()
 	addr := fmt.Sprintf("%s:%d", *server, *port)
 	rdb := redis.NewClient(&redis.Options{Addr: addr})
+
+	value := make([]byte, *dataSize)
+	if !*randomVal {
+		for i := range value {
+			value[i] = 'x'
+		}
+	}
 
 	fmt.Printf("Job %d: inserting keys kv_%d, kv_%d, ... (stride %d)\n",
 		id, *startKey+id, *startKey+id+*conns, *conns)
 
 	for k := *startKey + id; k <= *totalKeys; k += *conns {
+		if *randomVal {
+			generateRandom(value)
+		}
+
 		key := "kv_" + strconv.Itoa(k)
 		for {
 			err := rdb.Set(ctx, key, value, 0).Err()
@@ -91,5 +100,13 @@ func doJob(id int, value []byte) {
 			atomic.AddInt64(&uploaded, 1)
 			break
 		}
+	}
+}
+
+func generateRandom(buf []byte) {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	for i := range buf {
+		nBig, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		buf[i] = letters[nBig.Int64()]
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Bulk load testing tool now supports a `-random` flag to generate random values during key loading operations, replacing previously fixed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->