### PR TITLE
Set FORK_HM_PROCESS OFF when build with Open log

### DIFF
--- a/concourse/scripts/build_tarball_open.bash
+++ b/concourse/scripts/build_tarball_open.bash
@@ -74,7 +74,7 @@ cmake .. \
   -DOPEN_LOG_SERVICE=ON \
   -DDISABLE_CKPT_REPORT=ON \
   -DDISABLE_CODE_LINE_IN_LOG=ON \
-  -DFORK_HM_PROCESS=ON \
+  -DFORK_HM_PROCESS=OFF \
   -DWITH_ASAN="${ASAN}"
 
 cmake --build . --config "${BUILD_TYPE}" -j"${NCORE}"


### PR DESCRIPTION
Open log service can not work with host manager in seperate process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings to optimize process handling during build operations.

---

**Note:** This change primarily affects internal build processes and may have minimal direct user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->