### PR TITLE
Fix CI test failed on multi-node with rocksdb handler

### DIFF
--- a/concourse/scripts/common.sh
+++ b/concourse/scripts/common.sh
@@ -2180,7 +2180,7 @@ function run_eloqkv_cluster_tests() {
       --core_number=2 \
       --enable_wal=false \
       --enable_data_store=true \
-      --eloq_data_path="/tmp/redis_server_data_0" \
+      --eloq_data_path="/tmp/redis_server_data_bootstrap" \
       --event_dispatcher_num=1 \
       --auto_redirect=true \
       --maxclients=1000000 \
@@ -2260,7 +2260,7 @@ function run_eloqkv_cluster_tests() {
       --core_number=2 \
       --enable_wal=true \
       --enable_data_store=true \
-      --eloq_data_path="/tmp/redis_server_data_0" \
+      --eloq_data_path="/tmp/redis_server_data_bootstrap" \
       --event_dispatcher_num=1 \
       --auto_redirect=true \
       --maxclients=1000000 \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test setup now removes stale Redis data directories before cluster tests to reduce flakiness.
  * Bootstrap execution disabled or skipped for pure-memory/in-memory modes to simplify initialization and avoid artifacts.
  * Bootstrap data handling standardized to use a dedicated bootstrap path across storage variants, reducing accidental reuse of existing data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->