### PR TITLE
chore: add release build with eloqstore as store and rocksdb as wal

### DIFF
--- a/concourse/pipeline/build_release_tarball.yml
+++ b/concourse/pipeline/build_release_tarball.yml
@@ -2,7 +2,7 @@ resources:
 - name: eloqkv_src_main
   type: git
   source:
-    branch: rel_x_x_0_eloqkv
+    branch: rel_x_x_x_eloqkv
     uri: git@github.com:eloqdata/eloqkv.git
     private_key: ((git-key))
     tag_regex: '^[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline to support an additional data store configuration for release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->