### PR TITLE
chore: add debug build for ubuntu24 in ci

### DIFF
--- a/concourse/pipeline/build_debug_tarball.yml
+++ b/concourse/pipeline/build_debug_tarball.yml
@@ -14,7 +14,7 @@ resources:
   - name: image_ubuntu2404_main
     type: registry-image
     source:
-      repository: eloqdata/eloq-ci-build-ubuntu2404
+      repository: eloqdata/eloq-dev-ci-ubuntu2404
 
   - name: logservice_src_main
     type: git


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured CI/CD build pipeline configuration with reorganized resource definitions.
  * Added support for Ubuntu 2404 build environment alongside existing Ubuntu 2204.
  * Enhanced build pipeline to support multiple storage backend configurations (ROCKSDB, ROCKSDB_CLOUD_S3, ELOQDSS variants).
  * Optimized pipeline execution with parallel operations and enforced sequential constraints where needed.
  * Added new source fetches for several components to support the expanded build matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->