### PR TITLE
fix: fix ttl object deserialize

### DIFF
--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -7231,7 +7231,8 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     case RedisObjectType::List:
     {
         obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-        RedisListTTLObject *list_obj = static_cast<RedisListTTLObject *>(obj_ptr);
+        RedisListTTLObject *list_obj =
+            static_cast<RedisListTTLObject *>(obj_ptr);
 
         assert(list_obj->HasTTL());
         list_obj->Deserialize(result_.data(), offset);
@@ -7242,7 +7243,8 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     case RedisObjectType::Hash:
     {
         obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-        RedisHashTTLObject *hash_obj = static_cast<RedisHashTTLObject *>(obj_ptr);
+        RedisHashTTLObject *hash_obj =
+            static_cast<RedisHashTTLObject *>(obj_ptr);
 
         assert(hash_obj->HasTTL());
         hash_obj->Deserialize(result_.data(), offset);
@@ -7258,7 +7260,8 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     case RedisObjectType::Zset:
     {
         obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-        RedisZsetTTLObject *zset_obj = static_cast<RedisZsetTTLObject *>(obj_ptr);
+        RedisZsetTTLObject *zset_obj =
+            static_cast<RedisZsetTTLObject *>(obj_ptr);
 
         assert(zset_obj->HasTTL());
         zset_obj->Deserialize(result_.data(), offset);

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -7230,13 +7230,8 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::List:
     {
-        RedisListTTLObject *list_obj = dynamic_cast<RedisListTTLObject *>(obj);
-
-        if (list_obj == nullptr)
-        {
-            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-            list_obj = static_cast<RedisListTTLObject *>(obj_ptr);
-        }
+        obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+        RedisListTTLObject *list_obj = static_cast<RedisListTTLObject *>(obj_ptr);
 
         assert(list_obj->HasTTL());
         list_obj->Deserialize(result_.data(), offset);
@@ -7246,13 +7241,8 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::Hash:
     {
-        RedisHashTTLObject *hash_obj = dynamic_cast<RedisHashTTLObject *>(obj);
-
-        if (hash_obj == nullptr)
-        {
-            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-            hash_obj = static_cast<RedisHashTTLObject *>(obj_ptr);
-        }
+        obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+        RedisHashTTLObject *hash_obj = static_cast<RedisHashTTLObject *>(obj_ptr);
 
         assert(hash_obj->HasTTL());
         hash_obj->Deserialize(result_.data(), offset);
@@ -7267,13 +7257,8 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::Zset:
     {
-        RedisZsetTTLObject *zset_obj = dynamic_cast<RedisZsetTTLObject *>(obj);
-
-        if (zset_obj == nullptr)
-        {
-            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-            zset_obj = static_cast<RedisZsetTTLObject *>(obj_ptr);
-        }
+        obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+        RedisZsetTTLObject *zset_obj = static_cast<RedisZsetTTLObject *>(obj_ptr);
 
         assert(zset_obj->HasTTL());
         zset_obj->Deserialize(result_.data(), offset);
@@ -7283,14 +7268,9 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::Set:
     {
+        obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
         RedisHashSetTTLObject *hashset_obj =
-            dynamic_cast<RedisHashSetTTLObject *>(obj);
-
-        if (hashset_obj == nullptr)
-        {
-            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-            hashset_obj = static_cast<RedisHashSetTTLObject *>(obj_ptr);
-        }
+            static_cast<RedisHashSetTTLObject *>(obj_ptr);
 
         assert(hashset_obj->HasTTL());
         hashset_obj->Deserialize(result_.data(), offset);

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -7230,7 +7230,14 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::List:
     {
-        RedisListTTLObject *list_obj = static_cast<RedisListTTLObject *>(obj);
+        RedisListTTLObject *list_obj = dynamic_cast<RedisListTTLObject *>(obj);
+
+        if (list_obj == nullptr)
+        {
+            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+            list_obj = static_cast<RedisListTTLObject *>(obj_ptr);
+        }
+
         assert(list_obj->HasTTL());
         list_obj->Deserialize(result_.data(), offset);
         result_ttl_obj = list_obj;
@@ -7239,7 +7246,14 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::Hash:
     {
-        RedisHashTTLObject *hash_obj = static_cast<RedisHashTTLObject *>(obj);
+        RedisHashTTLObject *hash_obj = dynamic_cast<RedisHashTTLObject *>(obj);
+
+        if (hash_obj == nullptr)
+        {
+            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+            hash_obj = static_cast<RedisHashTTLObject *>(obj_ptr);
+        }
+
         assert(hash_obj->HasTTL());
         hash_obj->Deserialize(result_.data(), offset);
         result_ttl_obj = hash_obj;
@@ -7253,7 +7267,14 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::Zset:
     {
-        RedisZsetTTLObject *zset_obj = static_cast<RedisZsetTTLObject *>(obj);
+        RedisZsetTTLObject *zset_obj = dynamic_cast<RedisZsetTTLObject *>(obj);
+
+        if (zset_obj == nullptr)
+        {
+            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+            zset_obj = static_cast<RedisZsetTTLObject *>(obj_ptr);
+        }
+
         assert(zset_obj->HasTTL());
         zset_obj->Deserialize(result_.data(), offset);
         result_ttl_obj = zset_obj;
@@ -7263,7 +7284,14 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     case RedisObjectType::Set:
     {
         RedisHashSetTTLObject *hashset_obj =
-            static_cast<RedisHashSetTTLObject *>(obj);
+            dynamic_cast<RedisHashSetTTLObject *>(obj);
+
+        if (hashset_obj == nullptr)
+        {
+            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+            hashset_obj = static_cast<RedisHashSetTTLObject *>(obj_ptr);
+        }
+
         assert(hashset_obj->HasTTL());
         hashset_obj->Deserialize(result_.data(), offset);
         result_ttl_obj = hashset_obj;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of restoring time-limited collections so lists, hashes, sets, and sorted sets correctly retain TTL and payload.
  * Reduced instances of restoration failures for TTL-enabled items, yielding more consistent behavior after recovery.
  * Enhanced deserialization during recovery to ensure restored objects are valid and usable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->