### PR TITLE
fix: recreate object at RecoverCommand::CommitOn

### DIFF
--- a/include/redis_hash_object.h
+++ b/include/redis_hash_object.h
@@ -147,6 +147,8 @@ public:
     void Deserialize(const char *buf, size_t &offset) override
     {
         size_t init_off = offset;
+        hash_map_.clear();
+        serialized_length_ = 0;
         // Check the object type.
         RedisObjectType obj_type =
             static_cast<RedisObjectType>(*(buf + offset));
@@ -363,6 +365,8 @@ public:
     void Deserialize(const char *buf, size_t &offset) override
     {
         size_t init_off = offset;
+        hash_map_.clear();
+        serialized_length_ = 0;
         // Check the object type.
         RedisObjectType obj_type =
             static_cast<RedisObjectType>(*(buf + offset));

--- a/include/redis_list_object.h
+++ b/include/redis_list_object.h
@@ -118,6 +118,7 @@ public:
 
     void Deserialize(const char *buf, size_t &offset) override
     {
+        list_object_.clear();
         serialized_length_ = 1 + sizeof(uint32_t);
         // Check the object type.
         RedisObjectType obj_type =
@@ -341,6 +342,7 @@ struct RedisListTTLObject : public RedisListObject
 
     void Deserialize(const char *buf, size_t &offset) override
     {
+        list_object_.clear();
         serialized_length_ = 1 + sizeof(uint32_t);
         // Check the object type.
         RedisObjectType obj_type =

--- a/include/redis_zset_object.h
+++ b/include/redis_zset_object.h
@@ -126,6 +126,8 @@ public:
 
     void Deserialize(const char *buf, size_t &offset) override
     {
+        z_ordered_set_.clear();
+        z_hash_map_.clear();
         serialized_length_ = 1 + sizeof(uint32_t);
         // Check the object type.
         RedisObjectType obj_type =
@@ -465,6 +467,8 @@ public:
 
     void Deserialize(const char *buf, size_t &offset) override
     {
+        z_ordered_set_.clear();
+        z_hash_map_.clear();
         serialized_length_ = 1 + sizeof(uint32_t);
         // Check the object type.
         RedisObjectType obj_type =

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -7201,6 +7201,19 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     size_t offset = 0;
 
     txservice::TxObject *result_ttl_obj = obj_ptr;
+    auto recover_into = [&](auto *typed_obj)
+    {
+        using T = std::remove_pointer_t<decltype(typed_obj)>;
+        T *typed = dynamic_cast<T *>(obj);
+        if (typed == nullptr)
+        {
+            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
+            typed = static_cast<T *>(obj_ptr);
+        }
+        assert(typed->HasTTL());
+        typed->Deserialize(result_.data(), offset);
+        result_ttl_obj = typed;
+    };
 
     switch (obj_type)
     {
@@ -7211,38 +7224,19 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::String:
     {
-        RedisStringTTLObject *str_ttl_obj =
-            dynamic_cast<RedisStringTTLObject *>(obj);
-
-        if (str_ttl_obj == nullptr)
-        {
-            // Create Object directly since the old object here could be of any
-            // type(list, zset, string without ttl, ...)
-            obj_ptr = static_cast<TxObject *>(CreateObject(nullptr).release());
-            str_ttl_obj = static_cast<RedisStringTTLObject *>(obj_ptr);
-        }
-
-        assert(str_ttl_obj->HasTTL());
-        str_ttl_obj->Deserialize(result_.data(), offset);
-        result_ttl_obj = str_ttl_obj;
+        recover_into(static_cast<RedisStringTTLObject *>(nullptr));
         DLOG(INFO) << "RecoverObjectCommand::CommitOn ttl string";
         break;
     }
     case RedisObjectType::List:
     {
-        RedisListTTLObject *list_obj = static_cast<RedisListTTLObject *>(obj);
-        assert(list_obj->HasTTL());
-        list_obj->Deserialize(result_.data(), offset);
-        result_ttl_obj = list_obj;
+        recover_into(static_cast<RedisListTTLObject *>(nullptr));
         DLOG(INFO) << "RecoverObjectCommand::CommitOn ttl list";
         break;
     }
     case RedisObjectType::Hash:
     {
-        RedisHashTTLObject *hash_obj = static_cast<RedisHashTTLObject *>(obj);
-        assert(hash_obj->HasTTL());
-        hash_obj->Deserialize(result_.data(), offset);
-        result_ttl_obj = hash_obj;
+        recover_into(static_cast<RedisHashTTLObject *>(nullptr));
         DLOG(INFO) << "RecoverObjectCommand::CommitOn ttl hash";
         break;
     }
@@ -7253,20 +7247,13 @@ txservice::TxObject *RecoverObjectCommand::CommitOn(
     }
     case RedisObjectType::Zset:
     {
-        RedisZsetTTLObject *zset_obj = static_cast<RedisZsetTTLObject *>(obj);
-        assert(zset_obj->HasTTL());
-        zset_obj->Deserialize(result_.data(), offset);
-        result_ttl_obj = zset_obj;
+        recover_into(static_cast<RedisZsetTTLObject *>(nullptr));
         DLOG(INFO) << "RecoverObjectCommand::CommitOn ttl zset";
         break;
     }
     case RedisObjectType::Set:
     {
-        RedisHashSetTTLObject *hashset_obj =
-            static_cast<RedisHashSetTTLObject *>(obj);
-        assert(hashset_obj->HasTTL());
-        hashset_obj->Deserialize(result_.data(), offset);
-        result_ttl_obj = hashset_obj;
+        recover_into(static_cast<RedisHashSetTTLObject *>(nullptr));
         DLOG(INFO) << "RecoverObjectCommand::CommitOn ttl set";
         break;
     }

--- a/src/redis_set_object.cpp
+++ b/src/redis_set_object.cpp
@@ -490,6 +490,8 @@ void RedisHashSetObject::Serialize(std::string &str) const
 void RedisHashSetObject::Deserialize(const char *buf, size_t &offset)
 {
     size_t init_off = offset;
+    hash_set_.clear();
+    serialized_length_ = 0;
     // Check the object type.
     RedisObjectType obj_type = static_cast<RedisObjectType>(*(buf + offset));
     assert(obj_type == RedisObjectType::Set);
@@ -498,7 +500,6 @@ void RedisHashSetObject::Deserialize(const char *buf, size_t &offset)
     (void) obj_type;
     offset += 1;
 
-    assert(hash_set_.size() == 0);
     uint32_t ele_num = *reinterpret_cast<const uint32_t *>(buf + offset);
     offset += sizeof(uint32_t);
 
@@ -607,6 +608,8 @@ void RedisHashSetTTLObject::Serialize(std::string &str) const
 void RedisHashSetTTLObject::Deserialize(const char *buf, size_t &offset)
 {
     size_t init_off = offset;
+    hash_set_.clear();
+    serialized_length_ = 0;
     // Check the object type.
     RedisObjectType obj_type = static_cast<RedisObjectType>(*(buf + offset));
     assert(obj_type == RedisObjectType::TTLSet);
@@ -617,7 +620,6 @@ void RedisHashSetTTLObject::Deserialize(const char *buf, size_t &offset)
     ttl_ = *ttl_ptr;
     offset += sizeof(uint64_t);
 
-    assert(hash_set_.size() == 0);
     uint32_t ele_num = *reinterpret_cast<const uint32_t *>(buf + offset);
     offset += sizeof(uint32_t);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TTL recovery so expiration metadata for String, List, Hash, Zset and Set is preserved reliably during object recovery.
  * Deserialization now clears prior contents for List, Hash, Zset and Set objects before rebuilding, preventing stale or duplicated entries when loading data.
  * Recovery now reliably recreates the correct TTL-capable object when needed.
  * More robust deserialization state handling to avoid leftover state across loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->