### PR TITLE
Fix SREM and SMOVE no-op semantics

### DIFF
--- a/.github/workflows/semantic-regressions.yml
+++ b/.github/workflows/semantic-regressions.yml
@@ -1,0 +1,128 @@
+name: Semantic Regressions
+
+on:
+  pull_request:
+    paths:
+      - 'include/redis_command.h'
+      - 'src/redis_command.cpp'
+      - 'tests/unit/eloq/**'
+      - 'tests/integration/**'
+      - '.github/workflows/semantic-regressions.yml'
+  workflow_dispatch:
+
+jobs:
+  semantic-regressions:
+    runs-on: ubuntu-latest
+    container:
+      image: eloqdata/eloq-dev-ci-ubuntu2404:latest
+      options: --user root
+
+    steps:
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: eloqkv_src
+
+      - name: Setup private dependencies
+        env:
+          GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=accept-new"
+        run: |
+          git config --global --add safe.directory '*'
+          cd "$GITHUB_WORKSPACE"
+          git clone --recurse-submodules git@github.com:eloqdata/eloq_log_service.git logservice_src
+          git clone git@github.com:eloqdata/raft_host_manager.git raft_host_manager_src
+
+          rm -rf eloqkv_src/data_substrate/eloq_log_service
+          rm -rf eloqkv_src/data_substrate/tx_service/raft_host_manager
+          ln -s "$GITHUB_WORKSPACE/logservice_src" \
+                "$GITHUB_WORKSPACE/eloqkv_src/data_substrate/eloq_log_service"
+          ln -s "$GITHUB_WORKSPACE/raft_host_manager_src" \
+                "$GITHUB_WORKSPACE/eloqkv_src/data_substrate/tx_service/raft_host_manager"
+
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+            postgresql-client rsync patchelf tcl
+
+      - name: Download eloqkv-cli
+        working-directory: ${{ github.workspace }}/eloqkv_src
+        run: |
+          curl -fSL -o redis-cli \
+            "https://download.eloqdata.com/eloqkv/client/eloqkv-cli-7.2.5-ubuntu24-amd64"
+          chmod +x redis-cli
+
+      - name: Build eloqkv
+        working-directory: ${{ github.workspace }}/eloqkv_src
+        run: |
+          mkdir -p build && cd build
+          cmake .. \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DWITH_DATA_STORE=ROCKSDB \
+            -DWITH_LOG_SERVICE=ON \
+            -DWITH_LOG_STATE=ROCKSDB \
+            -DDISABLE_CKPT_REPORT=ON \
+            -DDISABLE_CODE_LINE_IN_LOG=ON \
+            -DWITH_ASAN=OFF \
+            -DOPEN_LOG_SERVICE=OFF \
+            -DFORK_HM_PROCESS=ON
+          cmake --build . -j$(nproc)
+
+      - name: Run unit regression tests
+        working-directory: ${{ github.workspace }}/eloqkv_src
+        run: |
+          mkdir -p tests/tmp/semantic-unit
+          cat > tests/tmp/semantic-unit/eloqkv.ini <<EOF
+          [local]
+          bind_all=true
+          ip=127.0.0.1
+          port=6379
+          eloq_data_path=${GITHUB_WORKSPACE}/eloqkv_src/tests/tmp/semantic-unit/runtime
+          core_number=2
+          event_dispatcher_num=1
+          bootstrap=true
+          enable_data_store=false
+          enable_wal=off
+          enable_io_uring=false
+          auto_redirect=true
+          maxclients=100000
+
+          [cluster]
+          ip_port_list=127.0.0.1:6379
+          txlog_group_replica_num=1
+          EOF
+
+          ./build/eloqkv --config=tests/tmp/semantic-unit/eloqkv.ini >/tmp/eloqkv-bootstrap.log 2>&1 || true
+          sed -i 's/bootstrap=true/bootstrap=false/' tests/tmp/semantic-unit/eloqkv.ini
+          ./build/eloqkv --config=tests/tmp/semantic-unit/eloqkv.ini >/tmp/eloqkv-unit.log 2>&1 &
+          SERVER_PID=$!
+          trap 'kill ${SERVER_PID} >/dev/null 2>&1 || true; wait ${SERVER_PID} >/dev/null 2>&1 || true' EXIT
+
+          for _ in $(seq 1 30); do
+            if ./redis-cli -p 6379 ping >/dev/null 2>&1; then
+              break
+            fi
+            sleep 1
+          done
+
+          tclsh tests/test_helper.tcl \
+            --host 127.0.0.1 \
+            --port 6379 \
+            --tags -needs:repl \
+            --tags -needs:config-maxmemory \
+            --tags -needs:debug \
+            --tags -needs:redis_config \
+            --tags -needs:redis_expire \
+            --tags -needs:slow_test \
+            --tags -needs:support_cmd_later \
+            --single /unit/eloq/regression_semantics
+
+      - name: Run integration regression tests
+        working-directory: ${{ github.workspace }}/eloqkv_src
+        run: |
+          chmod +x tests/integration/semantic_regressions.sh
+          tests/integration/semantic_regressions.sh

--- a/include/redis_command.h
+++ b/include/redis_command.h
@@ -5100,7 +5100,7 @@ struct SRemCommand : public HashSetCommand
 
     bool ProceedOnNonExistentObject() const override
     {
-        return true;
+        return false;
     }
 
     bool ProceedOnExistentObject() const override
@@ -5118,7 +5118,7 @@ struct SRemCommand : public HashSetCommand
 
     void OutputResult(OutputHandler *reply) const override
     {
-        if (result_.err_code_ == RD_OK)
+        if (result_.err_code_ == RD_OK || result_.err_code_ == RD_NIL)
         {
             reply->OnInt(result_.ret_);
         }
@@ -5918,6 +5918,13 @@ public:
     void OutputResult(OutputHandler *reply) const override;
     bool IsPassed() const override
     {
+        if (curr_step_ == 0)
+        {
+            return cmd_src_->result_.err_code_ == RD_NIL ||
+                   (cmd_src_->result_.err_code_ == RD_OK &&
+                    cmd_src_->result_.ret_ == 0);
+        }
+
         if (cmd_src_->result_.err_code_ != RD_OK ||
             cmd_dst_->result_.err_code_ != RD_OK)
         {

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -6525,14 +6525,14 @@ bool SMoveCommand::HandleMiddleResult()
         return false;
     }
 
-    if (cmd_src_->result_.ret_ == 1)
+    if (cmd_src_->result_.err_code_ != RD_OK || cmd_src_->result_.ret_ != 1)
     {
-        // the EloqString in cmd_src_->vct_paras_ is of string_view type
-        // pointing to the string in SMOVE command, so the string_view will
-        // always be valid until the end of transaction.
-        cmd_dst_->vct_paras_.emplace_back(cmd_src_->vct_paras_[0].StringView());
+        return false;
     }
 
+    // The source member existed and was removed. Only now should we touch the
+    // destination key.
+    cmd_dst_->vct_paras_.emplace_back(cmd_src_->vct_paras_[0].StringView());
     return true;
 }
 
@@ -6542,7 +6542,7 @@ void SMoveCommand::OutputResult(OutputHandler *reply) const
     {
         if (cmd_dst_->result_.err_code_ == RD_OK)
         {
-            reply->OnInt(cmd_dst_->result_.ret_);
+            reply->OnInt(cmd_src_->result_.ret_);
         }
         else
         {
@@ -6552,8 +6552,17 @@ void SMoveCommand::OutputResult(OutputHandler *reply) const
     }
     else
     {
-        assert(cmd_src_->result_.err_code_ != RD_OK);
-        reply->OnError(redis_get_error_messages(cmd_src_->result_.err_code_));
+        if (cmd_src_->result_.err_code_ == RD_NIL ||
+            (cmd_src_->result_.err_code_ == RD_OK &&
+             cmd_src_->result_.ret_ == 0))
+        {
+            reply->OnInt(0);
+        }
+        else
+        {
+            reply->OnError(
+                redis_get_error_messages(cmd_src_->result_.err_code_));
+        }
     }
 }
 

--- a/tests/integration/semantic_regressions.sh
+++ b/tests/integration/semantic_regressions.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BIN_DIR="${ROOT_DIR}/build"
+SERVER_BIN="${BIN_DIR}/eloqkv"
+CLI_BIN="${ROOT_DIR}/redis-cli"
+RUNTIME_DIR="${ROOT_DIR}/tests/tmp/semantic-regressions"
+CONF_FILE="${RUNTIME_DIR}/eloqkv.ini"
+LOG_FILE="${RUNTIME_DIR}/server.log"
+
+mkdir -p "${RUNTIME_DIR}"
+rm -rf "${RUNTIME_DIR}/runtime"
+
+cat >"${CONF_FILE}" <<EOF
+[local]
+bind_all=true
+ip=127.0.0.1
+port=6379
+eloq_data_path=${RUNTIME_DIR}/runtime
+core_number=2
+event_dispatcher_num=1
+bootstrap=true
+enable_data_store=false
+enable_wal=off
+enable_io_uring=false
+auto_redirect=true
+maxclients=100000
+
+[cluster]
+ip_port_list=127.0.0.1:6379
+txlog_group_replica_num=1
+EOF
+
+"${SERVER_BIN}" --config="${CONF_FILE}" >"${LOG_FILE}" 2>&1 || true
+sed -i 's/bootstrap=true/bootstrap=false/' "${CONF_FILE}"
+
+"${SERVER_BIN}" --config="${CONF_FILE}" >"${LOG_FILE}" 2>&1 &
+SERVER_PID=$!
+trap 'kill ${SERVER_PID} >/dev/null 2>&1 || true; wait ${SERVER_PID} >/dev/null 2>&1 || true' EXIT
+
+for _ in $(seq 1 30); do
+    if "${CLI_BIN}" -p 6379 ping >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+"${CLI_BIN}" -p 6379 ping | grep -qx 'PONG'
+
+"${CLI_BIN}" -p 6379 flushall >/dev/null
+
+[[ "$("${CLI_BIN}" -p 6379 srem missing-set member)" == "0" ]]
+
+"${CLI_BIN}" -p 6379 set dst-string value >/dev/null
+[[ "$("${CLI_BIN}" -p 6379 smove missing-src dst-string member)" == "0" ]]
+[[ "$("${CLI_BIN}" -p 6379 get dst-string)" == "value" ]]
+
+"${CLI_BIN}" -p 6379 del src-set dst-set >/dev/null
+"${CLI_BIN}" -p 6379 sadd src-set member >/dev/null
+"${CLI_BIN}" -p 6379 sadd dst-set member >/dev/null
+[[ "$("${CLI_BIN}" -p 6379 smove src-set dst-set member)" == "1" ]]
+[[ -z "$("${CLI_BIN}" -p 6379 smembers src-set)" ]]
+[[ "$("${CLI_BIN}" -p 6379 smembers dst-set)" == "member" ]]

--- a/tests/unit/eloq/regression_semantics.tcl
+++ b/tests/unit/eloq/regression_semantics.tcl
@@ -1,0 +1,41 @@
+start_server {
+    tags {"set"}
+    overrides {
+        "set-max-intset-entries" 512
+        "set-max-listpack-entries" 128
+        "set-max-listpack-value" 32
+    }
+} {
+    test {SREM on a missing key returns 0} {
+        r del missing-set{t}
+        assert_equal 0 [r srem missing-set{t} member]
+    }
+
+    test {SMOVE with a missing source does not touch a wrongtype destination} {
+        r del src-missing{t} dst-string{t}
+        r set dst-string{t} value
+
+        assert_equal 0 [r smove src-missing{t} dst-string{t} member]
+        assert_equal value [r get dst-string{t}]
+    }
+
+    test {SMOVE with a missing member does not touch a wrongtype destination} {
+        r del src-set{t} dst-string{t}
+        r sadd src-set{t} existing
+        r set dst-string{t} value
+
+        assert_equal 0 [r smove src-set{t} dst-string{t} missing]
+        assert_equal {existing} [lsort [r smembers src-set{t}]]
+        assert_equal value [r get dst-string{t}]
+    }
+
+    test {SMOVE returns 1 when the destination already contains the member} {
+        r del src-set{t} dst-set{t}
+        r sadd src-set{t} member
+        r sadd dst-set{t} member
+
+        assert_equal 1 [r smove src-set{t} dst-set{t} member]
+        assert_equal {} [r smembers src-set{t}]
+        assert_equal {member} [lsort [r smembers dst-set{t}]]
+    }
+}


### PR DESCRIPTION
## Summary
- fix `SREM` so missing keys short-circuit and return `0` instead of surfacing `RD_NIL`
- fix `SMOVE` so missing source/missing member no-ops do not touch the destination key, and return values follow Redis semantics
- add focused semantic regression coverage and a PR workflow for these cases

## Verification
- rebuilt `eloqkv`
- verified locally on a clean single-node instance:
  - `SREM missing-set member -> 0`
  - `SMOVE missing-src wrongtype-dst -> 0` and destination unchanged
  - `SMOVE missing-member wrongtype-dst -> 0` and source/destination unchanged
  - `SMOVE src dst member` where destination already has the member -> `1`

## Notes
- did not run the full test suite in this environment