### PR TITLE
feat & doc : Support tenant namespace isolation and add cluster broadcast for namespace updates

### DIFF
--- a/doc/en/namespace.md
+++ b/doc/en/namespace.md
@@ -1,0 +1,77 @@
+# Namespace
+
+## Use Cases
+- Tenant Isolation: The system supports a scale of millions or tens of millions of namespaces. Namespaces restrict data access, providing isolation between tenants.
+
+## Usage Workflow
+
+### 1. Create a Namespace
+Run the command:
+```text
+eloqkv ❯ NAMESPACE ADD tenant1
+"bXluZXduYW1lc3BhY2V0b2"
+```
+
+### 2. Authenticate
+Authenticate using the token:
+```text
+eloqkv ❯ AUTH bXluZXduYW1lc3BhY2V0b2
+OK
+```
+
+### 3. Read and Write Data
+Write and read data:
+```text
+eloqkv ❯ SET key1 value1
+OK
+eloqkv ❯ GET key1
+"value1"
+```
+
+## Key Isolation
+- During `AUTH` authentication, the system uses tokens to distinguish namespaces.
+- A connection to a namespace only accesses keys of that namespace.
+- Client connections in tenant namespaces cannot execute the `SELECT` command.
+
+## Authentication Method
+To access a namespace:
+1. Connect to the server.
+2. Run `AUTH <token>`.
+The connection shifts to the namespace associated with the token.
+
+## Administration
+Except for `NAMESPACE CURRENT`, managing namespaces requires the connection to belong to the `default` namespace (and be authenticated with the `requirepass` password, if configured).
+
+### Commands
+
+#### NAMESPACE ADD <namespace_name>
+- Creates a namespace.
+- Returns the Token.
+- Example response: `"bXluZXduYW1lc3BhY2V0b2"`
+
+#### NAMESPACE GET <namespace_name>
+- Returns the Token of the namespace.
+- Example response: `"bXluZXduYW1lc3BhY2V0b2"`
+
+#### NAMESPACE GET *
+- Returns a list of namespaces and tokens.
+- Example response:
+  ```text
+  1) "tenant1"
+  2) "bXluZXduYW1lc3BhY2V0b2"
+  3) "tenant2"
+  4) "YW5vdGhlcm5hbWVzcGFjZXRv"
+  ```
+
+#### NAMESPACE REFRESH <namespace_name>
+- Replaces the token of the namespace.
+- Returns the Token.
+- Example response: `"YW5vdGhlcm5hbWVzcGFjZXRv"`
+
+#### NAMESPACE DEL <namespace_name>
+- Deletes the namespace.
+- Example response: `"OK"`
+
+#### NAMESPACE CURRENT
+- Returns the namespace name of the connection.
+- Example response: `"tenant1"`

--- a/doc/zh/namespace.md
+++ b/doc/zh/namespace.md
@@ -1,0 +1,77 @@
+# 名字空间
+
+## 使用场景
+- 租户隔离：系统支持百万级或千万级数量的名字空间。名字空间限制数据访问范围，实现租户间的数据隔离。
+
+## 使用流程
+
+### 1. 创建名字空间
+执行命令：
+```text
+eloqkv ❯ NAMESPACE ADD tenant1
+"bXluZXduYW1lc3BhY2V0b2"
+```
+
+### 2. 认证
+使用生成的 Token 进行认证：
+```text
+eloqkv ❯ AUTH bXluZXduYW1lc3BhY2V0b2
+OK
+```
+
+### 3. 数据读写
+写入和读取数据：
+```text
+eloqkv ❯ SET key1 value1
+OK
+eloqkv ❯ GET key1
+"value1"
+```
+
+## 键隔离
+- `AUTH`认证时，通过不同的令牌区分不同的名字空间。
+- 连接仅访问自身名字空间中的键。
+- 名字空间的租户不支持 `SELECT` 命令。
+
+## 认证方式
+访问名字空间的步骤：
+1. 连接服务器。
+2. 执行 `AUTH <token>`。
+连接切换到与该 Token 关联的名字空间。
+
+## 管理
+除 `NAMESPACE CURRENT` 外，管理名字空间需要连接处于 `default` 名字空间（若配置了密码 `requirepass`，则连接还必须通过认证）。
+
+### 命令
+
+#### NAMESPACE ADD <namespace_name>
+- 创建名字空间。
+- 返回生成的 Token。
+- 返回值示例：`"bXluZXduYW1lc3BhY2V0b2"`
+
+#### NAMESPACE GET <namespace_name>
+- 返回该名字空间的 Token。
+- 返回值示例：`"bXluZXduYW1lc3BhY2V0b2"`
+
+#### NAMESPACE GET *
+- 返回名字空间与 Token 的列表。
+- 返回值示例：
+  ```text
+  1) "tenant1"
+  2) "bXluZXduYW1lc3BhY2V0b2"
+  3) "tenant2"
+  4) "YW5vdGhlcm5hbWVzcGFjZXRv"
+  ```
+
+#### NAMESPACE REFRESH <namespace_name>
+- 更新名字空间的 Token。
+- 返回 Token。
+- 返回值示例：`"YW5vdGhlcm5hbWVzcGFjZXRv"`
+
+#### NAMESPACE DEL <namespace_name>
+- 删除名字空间。
+- 返回值示例：`"OK"`
+
+#### NAMESPACE CURRENT
+- 返回连接的名字空间名称。
+- 返回值示例：`"tenant1"`

--- a/include/namespace/gc.h
+++ b/include/namespace/gc.h
@@ -27,6 +27,7 @@ private:
     std::vector<std::string> ScanGCRecords();
     bool CleanPrefixKeys(const std::string &old_prefix);
     void DeleteGCRecord(const std::string &gc_key);
+    void SleepWithStopCheck(int hundred_ms_units);
 
 private:
     RedisServiceImpl *server_;

--- a/include/redis_command.h
+++ b/include/redis_command.h
@@ -783,6 +783,8 @@ struct SelectCommand : public DirectCommand
 
 struct NamespaceCommand : public DirectCommand
 {
+    static constexpr const char *kOpNsFlush = "ns_flush";
+
     NamespaceCommand() = default;
     NamespaceCommand(std::string_view op,
                      std::string_view ns,

--- a/include/redis_service.h
+++ b/include/redis_service.h
@@ -182,10 +182,14 @@ public:
     // The total number of known nodes in the cluster
     uint32_t RedisClusterNodesCount();
 
-    uint16_t TxPortToRedisPort(uint16_t tx_port) const
+    static uint16_t TxPortToRedisPort(uint16_t tx_port)
     {
         return tx_port - 10000;
     }
+
+    bool IsLeader(uint32_t ng_id = 0) const;
+
+    bool BroadcastNsFlush(const std::string &ns);
 
     // Get all replica node status of node groups.
     // nodes_info is as: map{ng_id,[nodes_info,...]}

--- a/include/str.h
+++ b/include/str.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <butil/strings/string_piece.h>
+#include <strings.h>
+
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <utility>
+
+static inline bool IsEq(butil::StringPiece s1, std::string_view s2)
+{
+    const size_t len = s2.size();
+    return s1.size() == len && strncasecmp(s1.data(), s2.data(), len) == 0;
+}
+
+static inline bool IsEq(std::string_view s1, std::string_view s2)
+{
+    const size_t len = s2.size();
+    return s1.size() == len && strncasecmp(s1.data(), s2.data(), len) == 0;
+}
+
+static inline bool IsEq(const std::string &s1, std::string_view s2)
+{
+    const size_t len = s2.size();
+    return s1.size() == len && strncasecmp(s1.data(), s2.data(), len) == 0;
+}
+
+static inline bool IsEq(const char *s1, std::string_view s2)
+{
+    return IsEq(std::string_view(s1), s2);
+}
+
+template <typename... Args>
+static inline bool IsEqAny(butil::StringPiece s1, Args &&...args)
+{
+    return (IsEq(s1, std::forward<Args>(args)) || ...);
+}
+
+template <typename... Args>
+static inline bool IsEqAny(std::string_view s1, Args &&...args)
+{
+    return (IsEq(s1, std::forward<Args>(args)) || ...);
+}
+
+template <typename... Args>
+static inline bool IsEqAny(const std::string &s1, Args &&...args)
+{
+    return (IsEq(s1, std::forward<Args>(args)) || ...);
+}
+
+template <typename... Args>
+static inline bool IsEqAny(const char *s1, Args &&...args)
+{
+    return (IsEq(s1, std::forward<Args>(args)) || ...);
+}

--- a/src/namespace/gc.cpp
+++ b/src/namespace/gc.cpp
@@ -1,6 +1,9 @@
 #include "namespace/gc.h"
 
+#include <gflags/gflags.h>
 #include <glog/logging.h>
+
+DECLARE_bool(cluster_mode);
 
 #include "b255.h"
 #include "eloqkv_key.h"
@@ -44,6 +47,18 @@ void NamespaceGc::RunDaemon()
     LOG(INFO) << "Namespace GC daemon started.";
     while (!server_->IsStopping())
     {
+        // In cluster mode, namespace metadata and GC logs are replicated
+        // globally. Only the leader of node group 0 is responsible for scanning
+        // and cleaning up GC records to prevent redundant executions and
+        // transaction conflicts.
+        if (FLAGS_cluster_mode)
+        {
+            if (!server_->IsLeader())
+            {
+                SleepWithStopCheck(50);
+                continue;
+            }
+        }
         std::vector<std::string> gc_records = ScanGCRecords();
         if (server_->IsStopping())
         {
@@ -52,14 +67,7 @@ void NamespaceGc::RunDaemon()
 
         if (gc_records.empty())
         {
-            for (int i = 0; i < 300; ++i)
-            {
-                if (server_->IsStopping())
-                {
-                    break;
-                }
-                bthread_usleep(100 * 1000);  // 100ms
-            }
+            SleepWithStopCheck(300);
             continue;
         }
 
@@ -102,6 +110,18 @@ void NamespaceGc::RunDaemon()
         }
     }
     LOG(INFO) << "Namespace GC daemon stopped.";
+}
+
+void NamespaceGc::SleepWithStopCheck(int hundred_ms_units)
+{
+    for (int i = 0; i < hundred_ms_units; ++i)
+    {
+        if (server_->IsStopping())
+        {
+            break;
+        }
+        bthread_usleep(100 * 1000);
+    }
 }
 
 std::vector<std::string> NamespaceGc::ScanGCRecords()

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -76,6 +76,7 @@
 #include "redis_zset_object.h"
 #include "remote/remote_type.h"
 #include "sharder.h"
+#include "str.h"
 #include "tx_command.h"
 #include "tx_request.h"
 #include "tx_service.h"
@@ -1540,6 +1541,13 @@ void AuthCommand::OutputResult(OutputHandler *reply) const
 void NamespaceCommand::Execute(RedisServiceImpl *redis_impl,
                                RedisConnectionContext *ctx)
 {
+    if (!ctx)
+    {
+        result_.success = false;
+        result_.err_msg = "ERR missing connection context";
+        return;
+    }
+
     if (op_ == "current")
     {
         result_.success = true;
@@ -1547,23 +1555,34 @@ void NamespaceCommand::Execute(RedisServiceImpl *redis_impl,
         return;
     }
 
-    if (FLAGS_cluster_mode)
+    if (op_ == NamespaceCommand::kOpNsFlush)
     {
-        result_.success = false;
-        result_.err_msg =
-            "ERR forbidden to manage namespace when cluster mode was enabled";
+        if (!requirepass.empty())
+        {
+            if (token_ != requirepass)
+            {
+                result_.success = false;
+                result_.err_msg = "ERR unauthorized internal command";
+                return;
+            }
+        }
+        else
+        {
+            if (ctx->ns != "default")
+            {
+                result_.success = false;
+                result_.err_msg = "ERR unauthorized internal command";
+                return;
+            }
+        }
+        auto ns_mgr = redis_impl->GetNamespaceManager();
+        ns_mgr->RemoveMetadata(ns_);
+        result_.success = true;
+        result_.str_val = "OK";
         return;
     }
 
-    if (requirepass.empty())
-    {
-        result_.success = false;
-        result_.err_msg =
-            "ERR forbidden to manage namespace when requirepass was empty";
-        return;
-    }
-
-    if (!ctx->authenticated || ctx->ns != "default")
+    if (ctx->ns != "default" || (!requirepass.empty() && !ctx->authenticated))
     {
         result_.success = false;
         result_.err_msg =
@@ -1693,6 +1712,16 @@ void NamespaceCommand::Execute(RedisServiceImpl *redis_impl,
             }
         }
     }
+
+    if (result_.success && (op_ == "refresh" || op_ == "del"))
+    {
+        if (!redis_impl->BroadcastNsFlush(ns_))
+        {
+            result_.success = false;
+            result_.err_msg =
+                "ERR failed to propagate namespace flush to all cluster nodes";
+        }
+    }
 }
 
 void NamespaceCommand::OutputResult(OutputHandler *reply) const
@@ -1727,7 +1756,7 @@ void NamespaceCommand::OutputResult(OutputHandler *reply) const
     {
         reply->OnString(result_.str_val);
     }
-    else if (op_ == "del")
+    else if (op_ == "del" || op_ == NamespaceCommand::kOpNsFlush)
     {
         reply->OnStatus("OK");
     }
@@ -2156,22 +2185,22 @@ void ClientListCommand::OutputResult(OutputHandler *reply) const
 
 bool ClientListCommand::GetTypeByName(const char *name, Type *type)
 {
-    if (!strcasecmp(name, "normal"))
+    if (IsEq(name, "normal"))
     {
         *type = Type::NORMAL;
         return true;
     }
-    else if (!strcasecmp(name, "slave") || !strcasecmp(name, "replica"))
+    else if (IsEqAny(name, "slave", "replica"))
     {
         *type = Type::SLAVE;
         return true;
     }
-    else if (!strcasecmp(name, "pubsub"))
+    else if (IsEq(name, "pubsub"))
     {
         *type = Type::PUBSUB;
         return true;
     }
-    else if (!strcasecmp(name, "master"))
+    else if (IsEq(name, "master"))
     {
         *type = Type::MASTER;
         return true;
@@ -10634,6 +10663,13 @@ std::tuple<bool, NamespaceCommand> ParseNamespaceCommand(
     {
         return {true, NamespaceCommand("refresh", args[2], "")};
     }
+    else if ((args.size() == 3 || args.size() == 4) &&
+             subcommand == NamespaceCommand::kOpNsFlush)
+    {
+        std::string_view token = (args.size() == 4) ? args[3] : "";
+        return {true,
+                NamespaceCommand(NamespaceCommand::kOpNsFlush, args[2], token)};
+    }
     else
     {
         output->OnError(
@@ -10664,7 +10700,7 @@ std::tuple<bool, SlowLogCommand> ParseSlowLogCommand(
         return {false, SlowLogCommand()};
     }
 
-    if (0 == strcasecmp(args[1].data(), "get"))
+    if (IsEq(args[1], "get"))
     {
         if (args.size() == 2)
         {
@@ -10674,7 +10710,7 @@ std::tuple<bool, SlowLogCommand> ParseSlowLogCommand(
         {
             try
             {
-                int len = std::stoi(args[2].data());
+                int len = std::stoi(std::string(args[2]));
                 if (len < -1)
                 {
                     output->OnError(
@@ -10697,11 +10733,11 @@ std::tuple<bool, SlowLogCommand> ParseSlowLogCommand(
             return {false, SlowLogCommand()};
         }
     }
-    else if (0 == strcasecmp(args[1].data(), "reset"))
+    else if (IsEq(args[1], "reset"))
     {
         return {true, SlowLogCommand(SLOWLOG_RESET, -1)};
     }
-    else if (0 == strcasecmp(args[1].data(), "len"))
+    else if (IsEq(args[1], "len"))
     {
         return {true, SlowLogCommand(SLOWLOG_LEN, -1)};
     }
@@ -19476,19 +19512,19 @@ std::tuple<bool, SortCommand> ParseSortCommand(
     for (size_t j = 2; j < args.size(); j++)
     {
         size_t leftargs = args.size() - j - 1;
-        if (!strcasecmp(args[j].data(), "asc"))
+        if (IsEq(args[j], "asc"))
         {
             desc = false;
         }
-        else if (!strcasecmp(args[j].data(), "desc"))
+        else if (IsEq(args[j], "desc"))
         {
             desc = true;
         }
-        else if (!strcasecmp(args[j].data(), "alpha"))
+        else if (IsEq(args[j], "alpha"))
         {
             alpha = true;
         }
-        else if (!strcasecmp(args[j].data(), "limit") && leftargs >= 2)
+        else if (IsEq(args[j], "limit") && leftargs >= 2)
         {
             if (!string2ll(args[j + 1].data(), args[j + 1].size(), limit_start))
             {
@@ -19502,18 +19538,17 @@ std::tuple<bool, SortCommand> ParseSortCommand(
             }
             j += 2;
         }
-        else if (args[0] == "sort" && !strcasecmp(args[j].data(), "store") &&
-                 leftargs >= 1)
+        else if (args[0] == "sort" && IsEq(args[j], "store") && leftargs >= 1)
         {
             store_key.emplace(args[j + 1]);
             j++;
         }
-        else if (!strcasecmp(args[j].data(), "by") && leftargs >= 1)
+        else if (IsEq(args[j], "by") && leftargs >= 1)
         {
             by_pattern.emplace(args[j + 1]);
             j++;
         }
-        else if (!strcasecmp(args[j].data(), "get") && leftargs >= 1)
+        else if (IsEq(args[j], "get") && leftargs >= 1)
         {
             get_pattern_vec.emplace_back(args[j + 1]);
             j++;

--- a/src/redis_handler.cpp
+++ b/src/redis_handler.cpp
@@ -44,6 +44,7 @@
 #include "redis_replier.h"
 #include "redis_service.h"
 #include "sharder.h"
+#include "str.h"
 #include "tx_key.h"
 #include "tx_request.h"
 #include "tx_service.h"
@@ -1989,7 +1990,7 @@ brpc::RedisCommandHandlerResult ScriptHandler::Run(
         return brpc::REDIS_CMD_HANDLED;
     }
 
-    if (strcasecmp(args[1].data(), "flush") == 0)
+    if (IsEq(args[1], "flush"))
     {
         if (args.size() > 2)
         {
@@ -2007,7 +2008,7 @@ brpc::RedisCommandHandlerResult ScriptHandler::Run(
         output->SetStatus("OK");
         return brpc::REDIS_CMD_HANDLED;
     }
-    if (strcasecmp(args[1].data(), "exists") == 0)
+    if (IsEq(args[1], "exists"))
     {
         if (args.size() == 2)
         {
@@ -2018,7 +2019,7 @@ brpc::RedisCommandHandlerResult ScriptHandler::Run(
         redis_impl_->ScriptExists(args, output);
         return brpc::REDIS_CMD_HANDLED;
     }
-    if (strcasecmp(args[1].data(), "load") == 0)
+    if (IsEq(args[1], "load"))
     {
         if (args.size() == 2)
         {

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -22,12 +22,15 @@
 #include "redis_service.h"
 
 #include <absl/types/span.h>
+#include <brpc/channel.h>
+#include <bthread/bthread.h>
 #include <bthread/mutex.h>
 #include <bthread/task_group.h>
 #include <butil/strings/string_piece.h>
 #include <butil/strings/string_util.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <strings.h>
 #include <sys/resource.h>
 #include <sys/sysinfo.h>
 #include <sys/types.h>
@@ -73,6 +76,7 @@
 #include "redis_stats.h"
 #include "redis_string_match.h"
 #include "sharder.h"
+#include "str.h"
 #include "tx_key.h"
 // #include "store_handler/rocksdb_config.h"
 #include "eloqkv_catalog_factory.h"
@@ -402,11 +406,11 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
     IsolationLevel iso_level;
     CcProtocol protocol;
     // Support ReadCommitted and RepeatableRead.
-    if (strcasecmp(isolation_level.c_str(), "RepeatableRead") == 0)
+    if (IsEq(isolation_level, "RepeatableRead"))
     {
         iso_level = txservice::IsolationLevel::RepeatableRead;
     }
-    else if (strcasecmp(isolation_level.c_str(), "ReadCommitted") == 0)
+    else if (IsEq(isolation_level, "ReadCommitted"))
     {
         iso_level = txservice::IsolationLevel::ReadCommitted;
     }
@@ -416,15 +420,15 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
         return false;
     }
     // Support OCC, OccRead and Locking.
-    if (strcasecmp(cc_protocol.c_str(), "OCC") == 0)
+    if (IsEq(cc_protocol, "OCC"))
     {
         protocol = txservice::CcProtocol::OCC;
     }
-    else if (strcasecmp(cc_protocol.c_str(), "OCCRead") == 0)
+    else if (IsEq(cc_protocol, "OCCRead"))
     {
         protocol = txservice::CcProtocol::OccRead;
     }
-    else if (strcasecmp(cc_protocol.c_str(), "Locking") == 0)
+    else if (IsEq(cc_protocol, "Locking"))
     {
         protocol = txservice::CcProtocol::Locking;
     }
@@ -451,11 +455,11 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
                   "local", "txn_protocol", FLAGS_txn_protocol);
 
     // Support ReadCommitted and RepeatableRead.
-    if (strcasecmp(txn_iso_level.c_str(), "RepeatableRead") == 0)
+    if (IsEq(txn_iso_level, "RepeatableRead"))
     {
         txn_isolation_level_ = IsolationLevel::RepeatableRead;
     }
-    else if (strcasecmp(txn_iso_level.c_str(), "ReadCommitted") == 0)
+    else if (IsEq(txn_iso_level, "ReadCommitted"))
     {
         txn_isolation_level_ = IsolationLevel::ReadCommitted;
     }
@@ -467,15 +471,15 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
     }
 
     // Support OCC, OccRead and Locking.
-    if (strcasecmp(txn_protocol.c_str(), "OCC") == 0)
+    if (IsEq(txn_protocol, "OCC"))
     {
         txn_protocol_ = CcProtocol::OCC;
     }
-    else if (strcasecmp(txn_protocol.c_str(), "OCCRead") == 0)
+    else if (IsEq(txn_protocol, "OCCRead"))
     {
         txn_protocol_ = CcProtocol::OccRead;
     }
-    else if (strcasecmp(txn_protocol.c_str(), "Locking") == 0)
+    else if (IsEq(txn_protocol, "Locking"))
     {
         txn_protocol_ = CcProtocol::Locking;
     }
@@ -802,6 +806,178 @@ uint32_t RedisServiceImpl::RedisClusterSize()
 uint32_t RedisServiceImpl::RedisClusterNodesCount()
 {
     return txservice::Sharder::Instance().GetNodeCount();
+}
+
+bool RedisServiceImpl::IsLeader(uint32_t ng_id) const
+{
+    if (!FLAGS_cluster_mode)
+    {
+        return true;
+    }
+    return txservice::Sharder::Instance().NodeId() ==
+           txservice::Sharder::Instance().LeaderNodeId(ng_id);
+}
+
+bool RedisServiceImpl::BroadcastNsFlush(const std::string &ns)
+{
+    if (!FLAGS_cluster_mode)
+    {
+        return true;
+    }
+
+    auto node_id = txservice::Sharder::Instance().NodeId();
+    auto ng_configs = txservice::Sharder::Instance().GetNodeGroupConfigs();
+    std::unordered_set<uint32_t> visited_nodes;
+    std::vector<std::string> peer_endpoints_to_call;
+
+    for (const auto &[ng_id, nodes] : ng_configs)
+    {
+        for (const auto &node : nodes)
+        {
+            if (node.node_id_ == node_id)
+            {
+                continue;  // Skip self
+            }
+            if (visited_nodes.count(node.node_id_))
+            {
+                continue;  // Skip already visited node
+            }
+            visited_nodes.insert(node.node_id_);
+
+            std::string endpoint =
+                node.host_name_ + ":" +
+                std::to_string(RedisServiceImpl::TxPortToRedisPort(node.port_));
+            peer_endpoints_to_call.push_back(std::move(endpoint));
+        }
+    }
+
+    if (peer_endpoints_to_call.empty())
+    {
+        return true;
+    }
+
+    struct PeerCall
+    {
+        std::string endpoint;
+        std::unique_ptr<brpc::Channel> channel;
+        std::unique_ptr<brpc::Controller> controller;
+        std::unique_ptr<brpc::RedisRequest> request;
+        std::unique_ptr<brpc::RedisResponse> response;
+    };
+
+    std::vector<PeerCall> peer_calls;
+    peer_calls.reserve(peer_endpoints_to_call.size());
+
+    bool success = true;
+
+    for (const auto &endpoint : peer_endpoints_to_call)
+    {
+        auto channel = std::make_unique<brpc::Channel>();
+        brpc::ChannelOptions options;
+        options.protocol = brpc::PROTOCOL_REDIS;
+        options.timeout_ms = 500;
+        if (enable_tls_)
+        {
+            options.mutable_ssl_options();
+        }
+
+        if (channel->Init(endpoint.c_str(), &options) == 0)
+        {
+            auto request = std::make_unique<brpc::RedisRequest>();
+            butil::StringPiece components[4];
+            components[0] = "NAMESPACE";
+            components[1] = NamespaceCommand::kOpNsFlush;
+            components[2] = ns;
+            size_t num_components = 3;
+            if (!requirepass.empty())
+            {
+                components[3] = requirepass;
+                num_components = 4;
+            }
+
+            if (request->AddCommandByComponents(components, num_components))
+            {
+                auto controller = std::make_unique<brpc::Controller>();
+                auto response = std::make_unique<brpc::RedisResponse>();
+
+                channel->CallMethod(NULL,
+                                    controller.get(),
+                                    request.get(),
+                                    response.get(),
+                                    brpc::DoNothing());
+
+                peer_calls.push_back(PeerCall{endpoint,
+                                              std::move(channel),
+                                              std::move(controller),
+                                              std::move(request),
+                                              std::move(response)});
+            }
+            else
+            {
+                LOG(WARNING)
+                    << "Failed to add command components for NS flush to "
+                    << endpoint;
+                success = false;
+            }
+        }
+        else
+        {
+            LOG(WARNING) << "Failed to initialize brpc channel to " << endpoint;
+            success = false;
+        }
+    }
+
+    for (auto &call : peer_calls)
+    {
+        brpc::Join(call.controller->call_id());
+        if (call.controller->Failed())
+        {
+            LOG(WARNING) << "Failed to send NS flush asynchronously to peer "
+                         << call.endpoint << ": "
+                         << call.controller->ErrorText();
+            success = false;
+        }
+        else
+        {
+            const auto &res = *call.response;
+            if (res.reply_size() == 0)
+            {
+                LOG(WARNING)
+                    << "Received empty redis response for NS flush from peer "
+                    << call.endpoint;
+                success = false;
+            }
+            else
+            {
+                const auto &reply = res.reply(0);
+                if (reply.is_error())
+                {
+                    LOG(WARNING) << "NS flush failed on peer " << call.endpoint
+                                 << " with error: " << reply.error_message();
+                    success = false;
+                }
+                else if (reply.is_string())
+                {
+                    if (reply.data() != "OK")
+                    {
+                        LOG(WARNING)
+                            << "NS flush failed on peer " << call.endpoint
+                            << " with response: " << reply.data();
+                        success = false;
+                    }
+                }
+                else
+                {
+                    LOG(WARNING) << "NS flush failed on peer " << call.endpoint
+                                 << " with unexpected response type: "
+                                 << brpc::RedisReplyTypeToString(reply.type());
+                    success = false;
+                }
+            }
+        }
+    }
+
+    return success;
 }
 
 void RedisServiceImpl::GetReplicaNodesStatus(
@@ -5892,26 +6068,24 @@ bool RedisServiceImpl::AuthRequired(
         return false;
     }
 
-    // Bypass auth for "NAMESPACE CURRENT"
-    if (args.size() >= 2)
+    const auto &cmd = args[0];
+    if (IsEqAny(cmd, "auth", "quit", "hello", "reset"))
     {
-        std::string first(args[0].data(), args[0].size());
-        std::string second(args[1].data(), args[1].size());
-        std::transform(first.begin(), first.end(), first.begin(), ::tolower);
-        std::transform(second.begin(), second.end(), second.begin(), ::tolower);
-        if (first == "namespace" && second == "current")
+        return false;
+    }
+    else if (IsEq(cmd, "namespace"))
+    {
+        if (args.size() >= 2)
         {
-            return false;
+            const auto &subcmd = args[1];
+            if (IsEqAny(subcmd, "current", "ns_flush"))
+            {
+                return false;
+            }
         }
     }
 
-    constexpr std::array<std::string_view, 4> cmds_no_auth = {
-        "auth", "hello", "quit", "reset"};
-    std::string cmd_name(args[0].data(), args[0].size());
-    std::transform(
-        cmd_name.begin(), cmd_name.end(), cmd_name.begin(), ::tolower);
-    return std::find(cmds_no_auth.begin(), cmds_no_auth.end(), cmd_name) ==
-           cmds_no_auth.end();
+    return true;
 }
 
 std::unique_ptr<brpc::ConnectionContext> RedisServiceImpl::NewConnectionContext(


### PR DESCRIPTION
feat & doc : Support tenant namespace isolation and add cluster broadcast for namespace updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive namespace guides (English and Chinese) detailing tenant isolation, auth workflow, key visibility, and namespace lifecycle commands.

* **New Features**
  * Namespace flush propagation across cluster nodes.
  * Cluster-aware leader detection to coordinate namespace operations.
  * More robust, case-insensitive command option parsing.

* **Bug Fixes**
  * GC daemon idles on non-leader nodes in cluster mode to avoid redundant work.
  * Refined namespace auth rules so flush/current operations bypass or require auth correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->