### PR TITLE
fix: make slowlog timestamp Redis-compatible

### DIFF
--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -177,6 +177,15 @@ std::string ExecCommand(const std::string &cmd)
 
 namespace EloqKV
 {
+namespace
+{
+uint64_t SlowLogUnixTimeSeconds()
+{
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+}  // namespace
 
 const auto NUM_VCPU = std::thread::hardware_concurrency();
 
@@ -2260,7 +2269,7 @@ TxErrorCode RedisServiceImpl::MultiExec(
                         next_slow_log_unique_id_[group_id]++;
                     slow_log_[group_id][next_idx].execution_time_ = duration;
                     slow_log_[group_id][next_idx].timestamp_ =
-                        end.time_since_epoch().count();
+                        SlowLogUnixTimeSeconds();
                     slow_log_[group_id][next_idx].cmd_.clear();
                     for (auto &arg : *cmd_args_ptr)
                     {
@@ -4395,7 +4404,7 @@ void RedisServiceImpl::GenericCommand(RedisConnectionContext *ctx,
                     next_slow_log_unique_id_[group_id]++;
                 slow_log_[group_id][next_idx].execution_time_ = duration;
                 slow_log_[group_id][next_idx].timestamp_ =
-                    end.time_since_epoch().count();
+                    SlowLogUnixTimeSeconds();
                 slow_log_[group_id][next_idx].cmd_.clear();
                 for (auto &arg : cmd_args)
                 {
@@ -6115,7 +6124,7 @@ brpc::RedisCommandHandlerResult RedisServiceImpl::DispatchCommand(
                     next_slow_log_unique_id_[group_id]++;
                 slow_log_[group_id][next_idx].execution_time_ = duration;
                 slow_log_[group_id][next_idx].timestamp_ =
-                    end.time_since_epoch().count();
+                    SlowLogUnixTimeSeconds();
                 slow_log_[group_id][next_idx].cmd_.clear();
                 for (auto &arg : args)
                 {

--- a/tests/unit/eloq/slowlog.tcl
+++ b/tests/unit/eloq/slowlog.tcl
@@ -38,13 +38,16 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
     } {0}
 
     test {SLOWLOG - logged entry sanity check} {
+        set before [clock seconds]
         r client setname foobar
         r debug sleep 0.2
+        set after [clock seconds]
         set e [lindex [r slowlog get] 0]
         assert_equal [llength $e] 6
         if {!$::external} {
             assert_equal [lindex $e 0] 107
         }
+        assert_equal [expr {[lindex $e 1] >= $before && [lindex $e 1] <= $after}] 1
         assert_equal [expr {[lindex $e 2] > 100000}] 1
         assert_equal [lindex $e 3] {debug sleep 0.2}
         assert_equal {foobar} [lindex $e 5]

--- a/tests/unit/slowlog.tcl
+++ b/tests/unit/slowlog.tcl
@@ -37,13 +37,16 @@ start_server {tags {"slowlog"} overrides {slowlog-log-slower-than 1000000}} {
     } {0}
 
     test {SLOWLOG - logged entry sanity check} {
+        set before [clock seconds]
         r client setname foobar
         r debug sleep 0.2
+        set after [clock seconds]
         set e [lindex [r slowlog get] 0]
         assert_equal [llength $e] 6
         if {!$::external} {
             assert_equal [lindex $e 0] 107
         }
+        assert_equal [expr {[lindex $e 1] >= $before && [lindex $e 1] <= $after}] 1
         assert_equal [expr {[lindex $e 2] > 100000}] 1
         assert_equal [lindex $e 3] {debug sleep 0.2}
         assert_equal {foobar} [lindex $e 5]


### PR DESCRIPTION
## Summary
- store slowlog timestamps as Unix epoch seconds using system clock
- keep slowlog duration collection unchanged
- add test assertions to verify returned timestamps match wall-clock time

## Problem
EloqKV slowlog was writing the  field from , which does not represent real wall-clock time and is not compatible with Redis  semantics.

## Testing
- not fully run locally
- added slowlog unit assertions for timestamp wall-clock range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved the accuracy and consistency of timestamps recorded in slow-log entries across both command execution and transaction-related slow-log recording, leading to more reliable performance monitoring.

## Tests
* Strengthened slow-log “logged entry sanity check” coverage by capturing time just before and after the slow operation and asserting the slow-log timestamp falls within the expected interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->