### PR TITLE
fix(slowlog): store timestamp in nanoseconds, output seconds

### DIFF
--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -3639,7 +3639,9 @@ void SlowLogCommand::OutputResult(OutputHandler *reply) const
         {
             reply->OnArrayStart(6);
             reply->OnInt(entry.id_);
-            reply->OnInt(entry.timestamp_);
+            // timestamp_ is stored in nanoseconds for accurate cross-core
+            // ordering; SLOWLOG GET reports whole unix seconds like Redis.
+            reply->OnInt(entry.timestamp_ / 1000000000);
             reply->OnInt(entry.execution_time_);
             reply->OnArrayStart(entry.cmd_.size());
             for (const auto &cmd : entry.cmd_)

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -179,9 +179,14 @@ namespace EloqKV
 {
 namespace
 {
-uint64_t SlowLogUnixTimeSeconds()
+// Wall-clock unix time in nanoseconds. Stored on each slow-log entry so the
+// cross-core merge in GetSlowLog() can order entries by actual execution time;
+// SLOWLOG GET converts it to whole seconds on output for Redis compatibility.
+// (Seconds alone is too coarse: entries on different cores within the same
+// second tie, and the merge then orders them by core index, not by time.)
+uint64_t SlowLogUnixTimeNanos()
 {
-    return std::chrono::duration_cast<std::chrono::seconds>(
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
                std::chrono::system_clock::now().time_since_epoch())
         .count();
 }
@@ -2269,7 +2274,7 @@ TxErrorCode RedisServiceImpl::MultiExec(
                         next_slow_log_unique_id_[group_id]++;
                     slow_log_[group_id][next_idx].execution_time_ = duration;
                     slow_log_[group_id][next_idx].timestamp_ =
-                        SlowLogUnixTimeSeconds();
+                        SlowLogUnixTimeNanos();
                     slow_log_[group_id][next_idx].cmd_.clear();
                     for (auto &arg : *cmd_args_ptr)
                     {
@@ -4404,7 +4409,7 @@ void RedisServiceImpl::GenericCommand(RedisConnectionContext *ctx,
                     next_slow_log_unique_id_[group_id]++;
                 slow_log_[group_id][next_idx].execution_time_ = duration;
                 slow_log_[group_id][next_idx].timestamp_ =
-                    SlowLogUnixTimeSeconds();
+                    SlowLogUnixTimeNanos();
                 slow_log_[group_id][next_idx].cmd_.clear();
                 for (auto &arg : cmd_args)
                 {
@@ -6124,7 +6129,7 @@ brpc::RedisCommandHandlerResult RedisServiceImpl::DispatchCommand(
                     next_slow_log_unique_id_[group_id]++;
                 slow_log_[group_id][next_idx].execution_time_ = duration;
                 slow_log_[group_id][next_idx].timestamp_ =
-                    SlowLogUnixTimeSeconds();
+                    SlowLogUnixTimeNanos();
                 slow_log_[group_id][next_idx].cmd_.clear();
                 for (auto &arg : args)
                 {


### PR DESCRIPTION
Commit #490 changed the slow-log entry timestamp to whole unix seconds for Redis compatibility. But timestamp_ is also the sort key used by GetSlowLog() to merge the per-core slow logs in time order. With second-granularity timestamps, entries produced on different cores within the same second compare equal, so the merge falls back to ordering by core index instead of actual execution time. Under core_number > 1 this makes SLOWLOG GET return the wrong newest entry -- e.g. it reports the preceding `slowlog reset` instead of the command that ran after it, failing the slowlog.tcl assertions.

Keep the wall-clock value in nanoseconds (system_clock) on the entry so the cross-core merge orders by real execution time, and divide by 1e9 only when emitting the SLOWLOG GET reply so the reported value stays whole unix seconds (still satisfies the timestamp range assertion added in #490).

uint64 nanoseconds does not overflow until ~year 2554.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Slow log timestamp handling has been enhanced with improved precision to ensure more accurate ordering of command execution records across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->