### PR TITLE
refactor: move expensive info stats to standalone commands

### DIFF
--- a/include/redis_command.h
+++ b/include/redis_command.h
@@ -352,6 +352,9 @@ enum struct RedisCommandType
     ELOQVEC_DELETE = 184,
     ELOQVEC_SEARCH = 185,
 #endif
+#ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+    KEYSPACE = 186,
+#endif
 };
 
 // Anchors: fail the build if any value above is accidentally shifted
@@ -380,6 +383,9 @@ static_assert(static_cast<int>(RedisCommandType::FAULT_INJECT) == 177);
 #ifdef VECTOR_INDEX_ENABLED
 static_assert(static_cast<int>(RedisCommandType::ELOQVEC_CREATE) == 178);
 static_assert(static_cast<int>(RedisCommandType::ELOQVEC_SEARCH) == 185);
+#endif
+#ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+static_assert(static_cast<int>(RedisCommandType::KEYSPACE) == 186);
 #endif
 
 enum RedisResultType
@@ -883,9 +889,6 @@ struct InfoCommand : public DirectCommand
     std::string enable_wal_;
     uint32_t node_memory_limit_mb_{0};
 
-    int64_t data_memory_allocated_{0};
-    int64_t data_memory_committed_{0};
-    uint64_t last_ckpt_ts_{0};
     int event_dispatcher_num_{0};
     std::string os_info_;
     std::string executable_path_;
@@ -902,13 +905,33 @@ struct InfoCommand : public DirectCommand
     int64_t multi_cmd_count_{0};
     int64_t cmds_per_sec_{0};
     double cmd_latency_{0};
-    std::vector<int64_t> dbsizes_;
-#ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
-    uint64_t store_disk_keys_{0};
-#endif
+};
+
+struct MemoryStatsCommand : public DirectCommand
+{
+    void Execute(RedisServiceImpl *redis_impl,
+                 RedisConnectionContext *ctx) override;
+
+    void OutputResult(OutputHandler *reply) const override;
+
+    uint64_t data_memory_allocated_{0};
+    uint64_t data_memory_committed_{0};
+    uint64_t last_ckpt_ts_{0};
 };
 
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+struct KeyspaceCommand : public DirectCommand
+{
+    KeyspaceCommand() = default;
+
+    void Execute(RedisServiceImpl *redis_impl,
+                 RedisConnectionContext *ctx) override;
+    void OutputResult(OutputHandler *reply) const override;
+
+    std::vector<int64_t> dbsizes_;
+    uint64_t store_disk_keys_{0};
+};
+
 struct CompactCommand : public DirectCommand
 {
     CompactCommand() = default;
@@ -7945,6 +7968,9 @@ std::tuple<bool, InfoCommand> ParseInfoCommand(
     const std::vector<std::string_view> &args, OutputHandler *output);
 
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+std::tuple<bool, KeyspaceCommand> ParseKeyspaceCommand(
+    const std::vector<std::string_view> &args, OutputHandler *output);
+
 std::tuple<bool, CompactCommand> ParseCompactCommand(
     const std::vector<std::string_view> &args, OutputHandler *output);
 #endif

--- a/include/redis_handler.h
+++ b/include/redis_handler.h
@@ -259,6 +259,24 @@ private:
 };
 
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+class KeyspaceCommandHandler : public RedisCommandHandler
+{
+public:
+    explicit KeyspaceCommandHandler(RedisServiceImpl *redis_impl)
+        : redis_impl_(redis_impl)
+    {
+    }
+
+    brpc::RedisCommandHandlerResult Run(
+        RedisConnectionContext *ctx,
+        const std::vector<butil::StringPiece> &args,
+        brpc::RedisReply *output,
+        bool /*flush_batched*/) override;
+
+private:
+    RedisServiceImpl *redis_impl_;
+};
+
 class CompactCommandHandler : public RedisCommandHandler
 {
 public:

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -1799,7 +1799,6 @@ void InfoCommand::Execute(RedisServiceImpl *redis_impl,
         multi_cmd_count_ = RedisStats::GetMultiObjectCommandsCount();
         //  cmds_per_sec_ = RedisStats::GetCommandsPerSecond();
     }
-
 }
 
 void MemoryStatsCommand::Execute(RedisServiceImpl *redis_impl,
@@ -1834,7 +1833,8 @@ void KeyspaceCommand::Execute(RedisServiceImpl *redis_impl,
 
     dbsizes_ = DBSizeCommand::FetchDBSize(std::move(table_names));
     auto *store_hd = redis_impl->GetStoreHandler();
-    store_disk_keys_ = store_hd == nullptr ? 0 : store_hd->ApproxStoreKeyCount();
+    store_disk_keys_ =
+        store_hd == nullptr ? 0 : store_hd->ApproxStoreKeyCount();
 }
 
 void CompactCommand::Execute(RedisServiceImpl *redis_impl,
@@ -10785,8 +10785,7 @@ std::tuple<bool, KeyspaceCommand> ParseKeyspaceCommand(
 {
     if (args.size() != 1)
     {
-        output->OnError(
-            "ERR wrong number of arguments for 'keyspace' command");
+        output->OnError("ERR wrong number of arguments for 'keyspace' command");
         return {false, KeyspaceCommand()};
     }
 

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -111,6 +111,7 @@ const std::vector<std::pair<const char *, RedisCommandType>> command_types{{
     {"dbsize", RedisCommandType::DBSIZE},
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
     {"compact", RedisCommandType::COMPACT},
+    {"keyspace", RedisCommandType::KEYSPACE},
 #endif
     {"time", RedisCommandType::TIME},
     {"slowlog", RedisCommandType::SLOWLOG},
@@ -1779,28 +1780,6 @@ void InfoCommand::Execute(RedisServiceImpl *redis_impl,
     enable_wal_ = redis_impl->GetEnableWal();
     node_memory_limit_mb_ = redis_impl->GetNodeMemoryLimitMB();
 
-    if (set_section_.size() == 0 ||
-        set_section_.find("memory") != set_section_.end())
-    {
-        auto &local_shards = redis_impl->GetTxService()->CcShards();
-        size_t cnt = local_shards.Count();
-        CkptTsCc ckpt_req(cnt, node_id_);
-        for (size_t i = 0; i < cnt; i++)
-        {
-            local_shards.EnqueueCcRequest(i, &ckpt_req);
-        }
-        ckpt_req.Wait();
-        data_memory_allocated_ = ckpt_req.GetMemUsage();
-        data_memory_committed_ = ckpt_req.GetMemCommited();
-        last_ckpt_ts_ = ckpt_req.GetCkptTs();
-    }
-    else
-    {
-        data_memory_allocated_ = -1;
-        data_memory_committed_ = -1;
-        last_ckpt_ts_ = -1;
-    }
-
     event_dispatcher_num_ = redis_impl->GetEventDispatcherNum();
     version_ = redis_impl->GetVersion();
     os_info_ = redis_impl->GetOsInfo();
@@ -1821,28 +1800,43 @@ void InfoCommand::Execute(RedisServiceImpl *redis_impl,
         //  cmds_per_sec_ = RedisStats::GetCommandsPerSecond();
     }
 
-#ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
-    if (set_section_.size() == 0 ||
-        set_section_.find("keyspace") != set_section_.end())
-    {
-        std::vector<TableName> table_names;
-        size_t total_redis_table_cnt = redis_impl->GetRedisTableCount();
-        for (size_t db_id = 0; db_id < total_redis_table_cnt; ++db_id)
-        {
-            const TableName *tbn = redis_impl->RedisTableName(db_id);
-            table_names.emplace_back(
-                tbn->StringView(), tbn->Type(), TableEngine::EloqKv);
-        }
+}
 
-        dbsizes_ = DBSizeCommand::FetchDBSize(std::move(table_names));
-        auto *store_hd = redis_impl->GetStoreHandler();
-        store_disk_keys_ =
-            store_hd == nullptr ? 0 : store_hd->ApproxStoreKeyCount();
+void MemoryStatsCommand::Execute(RedisServiceImpl *redis_impl,
+                                 RedisConnectionContext *ctx)
+{
+    uint32_t node_id = Sharder::Instance().NodeId();
+    auto &local_shards = redis_impl->GetTxService()->CcShards();
+    size_t cnt = local_shards.Count();
+    CkptTsCc ckpt_req(cnt, node_id);
+    for (size_t i = 0; i < cnt; i++)
+    {
+        local_shards.EnqueueCcRequest(i, &ckpt_req);
     }
-#endif
+    ckpt_req.Wait();
+    data_memory_allocated_ = ckpt_req.GetMemUsage();
+    data_memory_committed_ = ckpt_req.GetMemCommited();
+    last_ckpt_ts_ = ckpt_req.GetCkptTs();
 }
 
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+void KeyspaceCommand::Execute(RedisServiceImpl *redis_impl,
+                              RedisConnectionContext *ctx)
+{
+    std::vector<TableName> table_names;
+    size_t total_redis_table_cnt = redis_impl->GetRedisTableCount();
+    for (size_t db_id = 0; db_id < total_redis_table_cnt; ++db_id)
+    {
+        const TableName *tbn = redis_impl->RedisTableName(db_id);
+        table_names.emplace_back(
+            tbn->StringView(), tbn->Type(), TableEngine::EloqKv);
+    }
+
+    dbsizes_ = DBSizeCommand::FetchDBSize(std::move(table_names));
+    auto *store_hd = redis_impl->GetStoreHandler();
+    store_disk_keys_ = store_hd == nullptr ? 0 : store_hd->ApproxStoreKeyCount();
+}
+
 void CompactCommand::Execute(RedisServiceImpl *redis_impl,
                              RedisConnectionContext *ctx)
 {
@@ -2585,11 +2579,6 @@ void InfoCommand::OutputResult(OutputHandler *reply) const
                   std::to_string(GetProcessVmRSSKb(getpid())) + " kb";
         result += "\r\ntotal_system_memory:" +
                   std::to_string(total_system_memory_kb_) + " kb";
-        result += "\r\ndata_memory_allocated:" +
-                  std::to_string(data_memory_allocated_) + " kb";
-        result += "\r\ndata_memory_committed:" +
-                  std::to_string(data_memory_committed_) + " kb";
-        // result += "data_memory_frag_ratio: " + ;  // TODO
         result +=
             "\r\nnode_memory_limit:" + std::to_string(node_memory_limit_mb_) +
             " mb ";
@@ -2605,7 +2594,6 @@ void InfoCommand::OutputResult(OutputHandler *reply) const
 
         result += "# Persistence";
 
-        result += "\r\nlast_success_ckpt_ts:" + std::to_string(last_ckpt_ts_);
         result += "\r\nenable_data_store:" + enable_data_store_;
         result += "\r\nenable_wal:" + enable_wal_;
     }
@@ -2680,31 +2668,48 @@ void InfoCommand::OutputResult(OutputHandler *reply) const
         }
     }
 
-#ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
-    if (set_section_.size() == 0 ||
-        set_section_.find("keyspace") != set_section_.end())
-    {
-        if (result.size() > 0)
-        {
-            result += "\r\n";
-        }
-
-        result += "# Keyspace";
-        for (size_t idx = 0; idx < dbsizes_.size(); ++idx)
-        {
-            if (dbsizes_[idx] > 0)
-            {
-                result += "\r\ndb" + std::to_string(idx) +
-                          ":keys=" + std::to_string(dbsizes_[idx]);
-            }
-        }
-        result += "\r\nstore:disk_keys=" + std::to_string(store_disk_keys_);
-    }
-#endif
-
     result += "\r\n";
     reply->OnString(result);
 }
+
+void MemoryStatsCommand::OutputResult(OutputHandler *reply) const
+{
+    reply->OnArrayStart(6);
+    reply->OnString("data_memory_allocated");
+    reply->OnInt(data_memory_allocated_);
+    reply->OnString("data_memory_committed");
+    reply->OnInt(data_memory_committed_);
+    reply->OnString("last_success_ckpt_ts");
+    reply->OnInt(last_ckpt_ts_);
+    reply->OnArrayEnd();
+}
+
+#ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+void KeyspaceCommand::OutputResult(OutputHandler *reply) const
+{
+    size_t db_count = 0;
+    for (int64_t dbsize : dbsizes_)
+    {
+        if (dbsize > 0)
+        {
+            ++db_count;
+        }
+    }
+
+    reply->OnArrayStart(db_count * 2 + 2);
+    for (size_t idx = 0; idx < dbsizes_.size(); ++idx)
+    {
+        if (dbsizes_[idx] > 0)
+        {
+            reply->OnString("db" + std::to_string(idx) + ":keys");
+            reply->OnInt(dbsizes_[idx]);
+        }
+    }
+    reply->OnString("store:disk_keys");
+    reply->OnInt(store_disk_keys_);
+    reply->OnArrayEnd();
+}
+#endif
 
 void ClusterCommand::OutputResult(OutputHandler *reply) const
 {
@@ -8452,6 +8457,17 @@ ParseMultiCommand(RedisServiceImpl *redis_impl,
             DirectRequest(ctx, std::make_unique<InfoCommand>(std::move(cmd)))};
     }
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+    case RedisCommandType::KEYSPACE:
+    {
+        auto [success, cmd] = ParseKeyspaceCommand(args, output);
+        if (!success)
+        {
+            return {false, DirectRequest{}};
+        }
+        return {success,
+                DirectRequest(
+                    ctx, std::make_unique<KeyspaceCommand>(std::move(cmd)))};
+    }
     case RedisCommandType::COMPACT:
     {
         auto [success, cmd] = ParseCompactCommand(args, output);
@@ -10764,6 +10780,19 @@ std::tuple<bool, InfoCommand> ParseInfoCommand(
 }
 
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+std::tuple<bool, KeyspaceCommand> ParseKeyspaceCommand(
+    const std::vector<std::string_view> &args, OutputHandler *output)
+{
+    if (args.size() != 1)
+    {
+        output->OnError(
+            "ERR wrong number of arguments for 'keyspace' command");
+        return {false, KeyspaceCommand()};
+    }
+
+    return {true, KeyspaceCommand()};
+}
+
 std::tuple<bool, CompactCommand> ParseCompactCommand(
     const std::vector<std::string_view> &args, OutputHandler *output)
 {

--- a/src/redis_handler.cpp
+++ b/src/redis_handler.cpp
@@ -5018,7 +5018,8 @@ brpc::RedisCommandHandlerResult MemoryHandler::Run(
     {
         if (cmd_arg_list.size() != 2)
         {
-            reply.OnError("wrong number of arguments for 'memory stats' command");
+            reply.OnError(
+                "wrong number of arguments for 'memory stats' command");
         }
         else
         {

--- a/src/redis_handler.cpp
+++ b/src/redis_handler.cpp
@@ -4984,7 +4984,7 @@ brpc::RedisCommandHandlerResult MemoryHandler::Run(
     std::vector<std::string_view> cmd_arg_list = Transform(args);
     if (cmd_arg_list.size() < 2)
     {
-        reply.OnError("wrong number of arguments for 'memory' command");
+        reply.OnError("ERR wrong number of arguments for 'memory' command");
         return brpc::REDIS_CMD_HANDLED;
     }
 

--- a/src/redis_handler.cpp
+++ b/src/redis_handler.cpp
@@ -650,6 +650,26 @@ brpc::RedisCommandHandlerResult InfoCommandHandler::Run(
 }
 
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+brpc::RedisCommandHandlerResult KeyspaceCommandHandler::Run(
+    RedisConnectionContext *ctx,
+    const std::vector<butil::StringPiece> &args,
+    brpc::RedisReply *output,
+    bool /*flush_batched*/)
+{
+    assert(args[0] == "keyspace");
+
+    RedisReplier reply(output);
+    std::vector<std::string_view> cmd_arg_list = Transform(args);
+
+    auto [success, cmd] = ParseKeyspaceCommand(cmd_arg_list, &reply);
+    if (success)
+    {
+        redis_impl_->ExecuteCommand(ctx, &cmd, &reply);
+    }
+
+    return brpc::REDIS_CMD_HANDLED;
+}
+
 brpc::RedisCommandHandlerResult CompactCommandHandler::Run(
     RedisConnectionContext *ctx,
     const std::vector<butil::StringPiece> &args,
@@ -4962,7 +4982,11 @@ brpc::RedisCommandHandlerResult MemoryHandler::Run(
 
     RedisReplier reply(output);
     std::vector<std::string_view> cmd_arg_list = Transform(args);
-    assert(cmd_arg_list.size() > 1);
+    if (cmd_arg_list.size() < 2)
+    {
+        reply.OnError("wrong number of arguments for 'memory' command");
+        return brpc::REDIS_CMD_HANDLED;
+    }
 
     if (stringcomp(cmd_arg_list[1], "usage", 1))
     {
@@ -4988,6 +5012,18 @@ brpc::RedisCommandHandlerResult MemoryHandler::Run(
                                         &reply,
                                         in_tx ? false : auto_commit_,
                                         in_tx);
+        }
+    }
+    else if (stringcomp(cmd_arg_list[1], "stats", 1))
+    {
+        if (cmd_arg_list.size() != 2)
+        {
+            reply.OnError("wrong number of arguments for 'memory stats' command");
+        }
+        else
+        {
+            MemoryStatsCommand cmd;
+            redis_impl_->ExecuteCommand(ctx, &cmd, &reply);
         }
     }
     else

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -1418,6 +1418,10 @@ void RedisServiceImpl::AddHandlers()
     AddCommandHandler("info", info_hd.get());
 
 #ifdef ELOQKV_WITH_DSS_ROCKSDB_CLOUD
+    auto &keyspace_hd =
+        hd_vec_.emplace_back(std::make_unique<KeyspaceCommandHandler>(this));
+    AddCommandHandler("keyspace", keyspace_hd.get());
+
     auto &compact_hd =
         hd_vec_.emplace_back(std::make_unique<CompactCommandHandler>(this));
     AddCommandHandler("compact", compact_hd.get());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `keyspace` Redis command in cloud-enabled builds.
  * Added `memory stats` to report memory allocation/commit and the last checkpoint timestamp.
* **Bug Fixes**
  * Improved `memory` command argument validation with clearer error replies for invalid subcommands/arity.
  * Updated `INFO` output to omit keyspace and moved memory/checkpoint fields, keeping response formatting consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->