### PR TITLE
fix: size redis command round counters by enum range

### DIFF
--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -743,7 +743,10 @@ bool RedisServiceImpl::Start(brpc::Server &brpc_server)
         redis_cmd_current_rounds_.resize(core_num_);
         for (auto &vec : redis_cmd_current_rounds_)
         {
-            vec.resize(command_types.size() + 10, 1);
+            // Indexed by RedisCommandType, whose values are pinned with gaps
+            // (optional commands occupy 176-186), so size by the enum range
+            // rather than the number of registered commands.
+            vec.resize(256, 1);
         }
 
         // The metrics registry and redis_meter are already created by


### PR DESCRIPTION
redis_cmd_current_rounds_ was sized by the number of registered commands but indexed by the RedisCommandType enum value. Optional commands are pinned with gaps at 176-186 (COMPACT/FAULT_INJECT/ELOQVEC_*/KEYSPACE), so their enum values exceed the registered-command count and indexing them read/wrote past the buffer (caught by ASan when running fault_inject). Size the per-core vector by the enum value range instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metrics initialization for Redis command tracking, making per-core counters more reliable and consistent across command types (including optional/gapped values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->