### PR TITLE
fix: size redis command round counters by enum range

### DIFF
--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -743,7 +743,10 @@ bool RedisServiceImpl::Start(brpc::Server &brpc_server)
         redis_cmd_current_rounds_.resize(core_num_);
         for (auto &vec : redis_cmd_current_rounds_)
         {
-            vec.resize(command_types.size() + 10, 1);
+            // Indexed by RedisCommandType, whose values are pinned with gaps
+            // (optional commands occupy 176-186), so size by the enum range
+            // rather than the number of registered commands.
+            vec.resize(256, 1);
         }
 
         // The metrics registry and redis_meter are already created by


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis metrics tracking to better handle command categories with gaps in their numbering, helping ensure more reliable runtime reporting.
  * Updated an embedded dependency reference to a newer revision, which may include general stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->