### PR TITLE
fix: INFO reports cluster_enabled:1 in single-node cluster mode

### DIFF
--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -2660,9 +2660,10 @@ void InfoCommand::OutputResult(OutputHandler *reply) const
         }
 
         result += "# Cluster";
+        bool cluster_enabled = FLAGS_cluster_mode || node_count_ > 1;
         result += "\r\ncluster_enabled:";
-        result += (node_count_ > 1 ? "1" : "0");
-        if (node_count_ > 1)
+        result += (cluster_enabled ? "1" : "0");
+        if (cluster_enabled)
         {
             result += "\r\ncluster_known_nodes:" + std::to_string(node_count_);
         }


### PR DESCRIPTION
## Problem

`INFO`'s cluster section derived `cluster_enabled` solely from the node count (`node_count_ > 1`), so a single node started with `--cluster_mode=true` still reported `cluster_enabled:0` — even though `CLUSTER INFO`/`NODES`/`SLOTS` already present a fully working one-node cluster (16384 slots assigned, `redis-cli --cluster check` passes). Cluster-aware clients that gate on `INFO`'s `cluster_enabled` therefore refused to treat the server as a cluster.

## Change

In `InfoCommand::OutputResult`, report `cluster_enabled:1` (and `cluster_known_nodes`) whenever `FLAGS_cluster_mode` is set or there is more than one node. This matches the flag's documented intent: "enable cluster mode even if there is only one node group, compatible with redis cluster protocol".

## Verification

Manually tested against a single-node server:

- `--cluster_mode=true`: `INFO cluster` returns `cluster_enabled:1` and `cluster_known_nodes:1`; `redis-cli --cluster check` passes; `redis-cli -c` reads/writes work.
- default (flag off): `INFO cluster` still returns `cluster_enabled:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cluster status reporting so cluster mode is shown as enabled when explicitly configured, including when only one node is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->