### PR TITLE
fix: commit watch txm and reply empty array on empty EXEC

### DIFF
--- a/docs/02-command-processing.md
+++ b/docs/02-command-processing.md
@@ -151,26 +151,30 @@ command to it (`src/redis_service.cpp:5999-6086`). Queued commands are parsed ea
 `ParseMultiCommand` (`src/redis_command.cpp:8351`) into a
 `std::variant<DirectRequest, ObjectCommandTxRequest, MultiObjectCommandTxRequest,
 CustomCommandRequest>`; parse failure marks the tx poisoned
-(`RD_ERR_EXEC_ABORT_FOR_PREV_ERROR`) and EXEC aborts. On `EXEC`, `MultiExec`
-(`src/redis_service.cpp:2055`) lazily creates **one** txm (`txn_isolation_level_`,
+(`RD_ERR_EXEC_ABORT_FOR_PREV_ERROR`) and EXEC replies an `EXECABORT` error. On `EXEC`,
+`MultiExec` (`src/redis_service.cpp:2076`) lazily creates **one** txm (`txn_isolation_level_`,
 `txn_protocol_`), optionally key-sorts the requests to reduce deadlocks
-(`--enable_cmd_sort`, off by default; 2109), executes them sequentially, then `CommitTx`.
-Divergence from vanilla Redis: any runtime error **aborts the whole transaction and returns
-nil** rather than executing remaining commands (2159-2352). `DISCARD` aborts and drops the
-queue. Commands not whitelisted in `ParseMultiCommand` get
-"Unsupported command in MULTI" (`src/redis_command.cpp:10499`).
+(`--enable_cmd_sort`, off by default), executes them sequentially, then `CommitTx`.
+An **empty queue** at EXEC commits the watch txm when one exists (so watch validation still
+runs) and replies an empty array `*0`. Divergence from vanilla Redis: any engine-level runtime
+error **aborts the whole transaction and replies a RESP null array** (`*-1`) rather than
+executing remaining commands. `DISCARD` aborts and drops the queue. Commands not whitelisted
+in `ParseMultiCommand` get "Unsupported command in MULTI" (`src/redis_command.cpp:10499`).
 
 **WATCH.** Handled before MULTI begins: `watch`/`unwatch` outside a queue create the
 `MultiTransactionHandler` early (`src/redis_service.cpp:6014-6041`). `WatchKeys`
-(`src/redis_handler.cpp:1849`) creates the txm immediately and reads the keys under it with a
-`MultiObjectCommandTxRequest` so RepeatableRead+OCC validation detects modification at commit —
-a changed watched key surfaces as an OCC failure and EXEC replies nil. `WATCH` inside MULTI or
+(`src/redis_handler.cpp:1871`) creates the txm immediately and reads the keys under it with a
+`MultiObjectCommandTxRequest` so validation detects modification at commit (watch-keys reads
+are promoted to RepeatableRead even under a lower configured isolation level,
+`data_substrate/tx_service/src/tx_execution.cpp:7139-7143`) — a changed watched key surfaces
+as an OCC failure and EXEC replies a null array (`*-1`), even when the queue is empty: the
+empty-EXEC path commits the watch txm so the txm is always reclaimed. `WATCH` inside MULTI or
 inside a BEGIN session is an error. Watching disables OCC retry (`tx_retrieable_ = false`).
 
 **Retry on OCC conflict.** With `--retry_on_occ_error` (default true), EXEC and Lua scripts are
 transparently re-parsed and re-executed when commit fails with
-`OCC_BREAK_REPEATABLE_READ`/`WRITE_WRITE_CONFLICT` (`src/redis_handler.cpp:1809-1827`,
-`src/redis_service.cpp:2601-2633`) — unless keys were WATCHed.
+`OCC_BREAK_REPEATABLE_READ`/`WRITE_WRITE_CONFLICT` (`src/redis_handler.cpp:1830-1848`,
+`src/redis_service.cpp:2645-2668`) — unless keys were WATCHed.
 
 **BEGIN/COMMIT/ROLLBACK (interactive sessions, EloqKV-specific).** `BeginHandler` stores a fresh
 txm in `ctx->txm` (`src/redis_handler.cpp:1619`). While set, every ordinary handler detects

--- a/include/redis_replier.h
+++ b/include/redis_replier.h
@@ -42,6 +42,9 @@ public:
     void OnArrayStart(unsigned len) override;
     void OnArrayEnd() override;
     void OnNil() override;
+    // Emit a RESP null array (*-1). Distinct from OnNil(), which emits a
+    // null bulk string ($-1).
+    void OnNullArray();
     void OnStatus(std::string_view str) override;
     void OnError(std::string_view str) override;
     void OnFormatError(const char *fmt, ...) override;

--- a/src/redis_handler.cpp
+++ b/src/redis_handler.cpp
@@ -1815,7 +1815,8 @@ brpc::RedisCommandHandlerResult MultiTransactionHandler::Run(
 
         if (error_ == RD_NIL)
         {
-            output->SetNullString();
+            // A watch-failure-aborted EXEC replies a null array, as in Redis.
+            output->SetNullArray();
         }
         else
         {

--- a/src/redis_replier.cpp
+++ b/src/redis_replier.cpp
@@ -74,6 +74,12 @@ void RedisReplier::OnNil()
     UpdateArray();
 }
 
+void RedisReplier::OnNullArray()
+{
+    cur_reply_->SetNullArray();
+    UpdateArray();
+}
+
 void RedisReplier::OnStatus(std::string_view str)
 {
     cur_reply_->SetStatus(butil::StringPiece(str.data(), str.size()));

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -2057,7 +2057,7 @@ TransactionExecution *RedisServiceImpl::NewTxm(IsolationLevel iso_level,
 #endif
     CODE_FAULT_INJECTOR("txm_iso_level_read_committed", {
         LOG(INFO) << "FaultInject txm_iso_level_read_committed"
-                  << "txID: " << txm->TxNumber();
+                  << " txID: " << txm->TxNumber();
         iso_level = IsolationLevel::ReadCommitted;
     });
 
@@ -2086,7 +2086,27 @@ TxErrorCode RedisServiceImpl::MultiExec(
     RedisReplier redis_reply(reply);
     if (cmd_reqs.empty())
     {
-        redis_reply.OnNil();
+        // EXEC with an empty queue. If WATCH created a txm, commit it so that
+        // validation of the watched keys runs: a broken watch fails the
+        // commit and EXEC replies a null array, as in Redis. Otherwise EXEC
+        // replies an empty array rather than nil.
+        if (txm != nullptr)
+        {
+            // The txm may be recycled once CommitTx returns; capture the tx
+            // number for logging first.
+            auto txn = txm->TxNumber();
+            auto [success, err_code] = CommitTx(txm);
+            if (!success)
+            {
+                LOG(WARNING)
+                    << "txn: " << txn << " empty MultiExec commit error: "
+                    << TxErrorMessage(err_code);
+                redis_reply.OnNullArray();
+                return err_code;
+            }
+        }
+        redis_reply.OnArrayStart(0);
+        redis_reply.OnArrayEnd();
         return TxErrorCode::NO_ERROR;
     }
 
@@ -2367,8 +2387,8 @@ TxErrorCode RedisServiceImpl::MultiExec(
                      << TxErrorMessage(tx_err_code);
         // abort txn
         AbortTx(txm);
-        // set nil
-        redis_reply.OnNil();
+        // An aborted EXEC replies a null array, as in Redis.
+        redis_reply.OnNullArray();
         return tx_err_code;
     }
 
@@ -2378,7 +2398,9 @@ TxErrorCode RedisServiceImpl::MultiExec(
     {
         LOG(WARNING) << "txn: " << txn
                      << " MultiExec commit error: " << TxErrorMessage(err_code);
-        redis_reply.OnNil();
+        // A failed commit (e.g. broken WATCH) replies a null array, as in
+        // Redis.
+        redis_reply.OnNullArray();
         return err_code;
     }
 

--- a/tests/unit/eloq/multi.tcl
+++ b/tests/unit/eloq/multi.tcl
@@ -235,8 +235,11 @@ start_server {tags {"multi"}} {
     # format of an EXEC reply must read it raw.
     proc exec_raw {} {
         r readraw 1
-        set res [r exec]
-        r readraw 0
+        try {
+            set res [r exec]
+        } finally {
+            r readraw 0
+        }
         return $res
     }
 

--- a/tests/unit/eloq/multi.tcl
+++ b/tests/unit/eloq/multi.tcl
@@ -230,6 +230,82 @@ start_server {tags {"multi"}} {
         r unwatch
     } {OK}
 
+    # Run EXEC in readraw mode and return the raw first RESP line. The Tcl
+    # client decodes *0, *-1 and $-1 all as {}, so tests that pin the wire
+    # format of an EXEC reply must read it raw.
+    proc exec_raw {} {
+        r readraw 1
+        set res [r exec]
+        r readraw 0
+        return $res
+    }
+
+    # Regression tests for #506: an empty EXEC must consume the watch txm
+    # (commit it so watch validation runs) and reply an empty array *0, not
+    # nil; an aborted EXEC replies a null array *-1, matching Redis.
+    test {empty EXEC replies an empty array, not nil (#506)} {
+        r multi
+        assert_equal "*0" [exec_raw]
+    } {}
+
+    test {WATCH then empty EXEC replies an empty array and consumes the watch txm (#506)} {
+        r set x 30
+        # Before the fix each cycle leaked one watch transaction.
+        for {set j 0} {$j < 10} {incr j} {
+            r watch x
+            r multi
+            assert_equal "*0" [exec_raw]
+        }
+        r ping
+    } {PONG}
+
+    test {WATCH modified key then empty EXEC replies a null array (#506)} {
+        r set x 30
+        r watch x
+        r set x 40
+        r multi
+        assert_equal "*-1" [exec_raw]
+    } {}
+
+    test {aborted non-empty EXEC replies a null array (#506)} {
+        r set x 30
+        r watch x
+        r set x 40
+        r multi
+        r ping
+        assert_equal "*-1" [exec_raw]
+    } {}
+
+    test {UNWATCH inside MULTI is immediate; empty EXEC replies an empty array (#506)} {
+        # EloqKV divergence from Redis: UNWATCH inside MULTI replies OK
+        # immediately instead of being queued (Redis queues it and EXEC
+        # replies a one-element array). The queue therefore stays empty and
+        # EXEC replies *0. Revisit this test if UNWATCH queueing is ever
+        # implemented.
+        r multi
+        r unwatch
+        assert_equal "*0" [exec_raw]
+    } {}
+
+    test {WATCH then UNWATCH inside MULTI still commits the watch txm on empty EXEC (#506)} {
+        r set x 30
+        r watch x
+        r multi
+        r unwatch
+        assert_equal "*0" [exec_raw]
+    } {}
+
+    test {failed second WATCH poisons EXEC into a null array (#506)} {
+        r set x 30
+        r watch x
+        r set x 40
+        # The second WATCH of a modified key fails with an OCC error and
+        # poisons the transaction.
+        assert_equal 1 [catch {r watch x}]
+        r multi
+        assert_equal "*-1" [exec_raw]
+    } {}
+
 # TODO: transaction conflict with flushdb/flushall. issue tracked. (tx1:watch-multi/exec; tx2:flushdb)
     # test {FLUSHALL is able to touch the watched keys} {
     #     r set x 30
@@ -901,15 +977,29 @@ start_server {tags {"multi"}} {
     } {*CONFIG SET failed*} {needs:redis_config}
     
     test "WatchKeys with ISO=ReadCommitted and EXEC fail on WATCHed key modified" {
-        r fault_inject watch_keys_txm_iso_level -1
-        r set x 30
-        r watch x
-        r set x 40
-        r multi
-        r ping
-        assert_equal {} [r exec]
-        r fault_inject watch_keys_txm_iso_level -1 remove
-    } {OK} {needs:fault_inject}
+        # The injector is named txm_iso_level_read_committed (NewTxm); the
+        # previous name here (watch_keys_txm_iso_level) never fired, leaving
+        # this test running on the default isolation level.
+        r fault_inject txm_iso_level_read_committed -1
+        try {
+            r set x 30
+            r watch x
+            r set x 40
+            r multi
+            r ping
+            assert_equal "*-1" [exec_raw]
+            # An empty EXEC must also validate the watch under ReadCommitted:
+            # watch-keys reads are promoted to RepeatableRead (#506).
+            r watch x
+            r set x 50
+            r multi
+            assert_equal "*-1" [exec_raw]
+        } finally {
+            # Always disarm the injector: leaked, it would downgrade every
+            # later transaction in this server process to ReadCommitted.
+            r fault_inject txm_iso_level_read_committed -1 remove
+        }
+    } {} {needs:fault_inject}
 
 # TODO: transaction conflict with flushdb/flushall. issue tracked.
     # test "Flushall while watching several keys by one client" {


### PR DESCRIPTION
## Summary

`WATCH k; MULTI; EXEC` with no queued commands leaked the RepeatableRead watch transaction and replied a RESP null instead of an empty array. This PR makes the empty-EXEC path consume the watch txm and aligns every aborted-EXEC reply with real Redis.

## Root cause

- `MultiExec` early-returned on an empty command list without committing or aborting the passed-in txm (`src/redis_service.cpp`).
- `MultiTransactionHandler::Run` then nulls `txm_` unconditionally, so the destructor's abort backstop never fires — the `TransactionExecution` is never returned to the pool.
- Additionally, every aborted-EXEC path replied a null **bulk string** (`$-1`) where Redis replies a null **array** (`*-1`), and an empty EXEC replied null instead of `*0`.

## Fix

- The empty-EXEC branch now **commits** the watch txm when one exists, so watched-key validation still runs: a broken watch fails the commit and EXEC replies `*-1` (Redis dirty-CAS semantics apply even to an empty queue); otherwise EXEC replies `*0`. `MultiExec` now consumes the txm on every path, restoring the invariant that every `NewTxm` pairs with `CommitTx`/`AbortTx`.
- All aborted-EXEC replies now emit a RESP null array via a new `RedisReplier::OnNullArray()` (exec-error abort, failed commit, poisoned pre-EXEC watch failure).
- The `WatchKeys with ISO=ReadCommitted` test enabled a fault injector that does not exist (`watch_keys_txm_iso_level`) and has been running on the default isolation level; it now uses the real injector (`txm_iso_level_read_committed`, guarded by `try/finally`) and also covers the empty-EXEC conflict, which works under ReadCommitted because watch-keys reads are promoted to RepeatableRead (`data_substrate/tx_service/src/tx_execution.cpp:7139-7143`).

## Wire behavior (verified with raw RESP probes)

| Scenario | Before | After | Redis |
|---|---|---|---|
| `MULTI; EXEC` (empty) | `$-1` | `*0` | `*0` |
| `WATCH k; MULTI; EXEC` (empty, unmodified) | `$-1` + **txm leak** | `*0` | `*0` |
| `WATCH k; k modified; MULTI; EXEC` (empty) | `$-1` + **txm leak** | `*-1` | `*-1` |
| `WATCH k; k modified; MULTI; PING; EXEC` | `$-1` | `*-1` | `*-1` |
| `MULTI; UNWATCH; EXEC` | `$-1` | `*0` | `*1` (`OK`) — see note |

Note: UNWATCH inside MULTI replies OK immediately in EloqKV instead of being queued (pre-existing divergence; Redis queues it and EXEC replies a one-element array). This change only moves that path's reply from `$-1` to `*0` — strictly closer to Redis — and a test pins the behavior so any future UNWATCH-queueing work must touch it consciously.

## Leak evidence (RSS of the server process, 50k-cycle pipelined batches)

| Workload | Before fix | After fix |
|---|---|---|
| 50k × `WATCH k; MULTI; EXEC` (batch 1) | **+677 MB** | +0.4 MB |
| 50k × `WATCH k; MULTI; EXEC` (batch 2) | **+690 MB** | +0.0 MB |
| 50k × `MULTI; PING; EXEC` (control) | +13 MB | (comparable) |

≈14 KB leaked per cycle before the fix, monotonic and never reclaimed. There is no exposed counter for live external txms (`ext_active_tx_cnt_` is private, no INFO/DEBUG/metrics surface), so the automated regression tests pin the reply semantics and repeatedly exercise the previously-leaking path; a TCL reclamation assertion needs new observability surface — tracked in #528.

## Tests

7 new raw-RESP regression tests in `tests/unit/eloq/multi.tcl` (the Tcl client decodes `*0`, `*-1`, `$-1` all as `{}`, so assertions use `readraw` via a small `exec_raw` helper), plus the repaired fault-injection test (Debug builds). Full `multi`/`multi2` suites pass on Release; `multi` incl. fault injection passes on Debug.

## Docs

`docs/02-command-processing.md` MULTI/EXEC and WATCH sections updated (empty-EXEC semantics, null-array replies, `EXECABORT` for queue-time errors, watch-read isolation promotion), per the repo doc-maintenance rule.

## Residual notes (reviewed, intentionally not changed here)

- `RedisReplier::OnNullArray()` is deliberately not part of the `OutputHandler` interface — only the RESP EXEC path emits it; Lua never does.
- The OCC retry loop's safety for watch txms rests on `WatchKeys` setting `tx_retrieable_ = false`; verified to hold on all current paths. A defensive assert could harden this for future edits.
- Engine-level exec-error aborts (`redis_service.cpp` exec-abort site) have no deterministic client-visible trigger without fault injection; the commit-failure site of the same shape is covered by tests.

Fixes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Redis RESP replies for WATCH/MULTI/EXEC to distinguish null array (`*-1`) from null bulk string.
  * Empty `EXEC` now returns `*0` (and commits an existing watch when applicable) instead of `nil`.
  * Aborted or failed `EXEC`/commit paths now return `*-1`.
* **Documentation**
  * Clarified MULTI/EXEC, WATCH, and OCC-retry semantics, including empty-queue EXEC and error reply behavior.
* **Tests**
  * Added regression tests for raw-wire `EXEC` outcomes and transactional watch/OCC edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->