### PR TITLE
test: make client.tcl CLIENT KILL deterministic against connection-registration race

### DIFF
--- a/tests/unit/eloq/client.tcl
+++ b/tests/unit/eloq/client.tcl
@@ -1,3 +1,21 @@
+# A freshly opened connection can already answer its own commands before the
+# brpc Acceptor has registered its socket in the connection map that CLIENT
+# LIST and CLIENT KILL enumerate. Under load (e.g. a 3-node cluster sharing
+# core_number=2) that registration lag is observable: CLIENT KILL <addr> scans
+# the map, finds no match and replies "No such client", failing the test.
+# CLIENT KILL only accepts the old-style addr:port form, and it and CLIENT LIST
+# read the exact same map, so wait until the target address is actually visible
+# in CLIENT LIST before killing it. That makes the kill deterministic without
+# reducing coverage.
+proc kill_client_by_addr {conn addr} {
+    wait_for_condition 50 20 {
+        [string match "*addr=$addr *" [$conn client list]]
+    } else {
+        fail "client $addr never registered in CLIENT LIST"
+    }
+    $conn client kill $addr
+}
+
 start_server {tags {"client"}} {
    test "CLIENT SETNAME/GETNAME" {
       r client setname test-client
@@ -11,7 +29,7 @@ start_server {tags {"client"}} {
       assert_match {*kill-client*} [$c client getname]
       set c_info [$c client info]
       regexp addr=(127.0.0.1:\[0-9\]+) $c_info - addr
-      r client kill $addr
+      kill_client_by_addr r $addr
       set client_list [r client list]
       regexp name=(kill-client) $client_list - name
       $c close
@@ -39,12 +57,12 @@ start_server {tags {"client"}} {
       assert_equal 1 [regexp $id3 [$rr2 client info]]
 
       regexp {addr\=([^\s]+)} [$rr client info]] _ addr2
-      r client kill $addr2
+      kill_client_by_addr r $addr2
       assert_equal 0 [regexp {$id2} [r client list]]
 
       regexp {addr\=([^\s]+)} [$rr2 client info]] _ addr3
-      r client kill $addr3
-      assert_equal 0 [regexp {$id3} [r client list]]      
+      kill_client_by_addr r $addr3
+      assert_equal 0 [regexp {$id3} [r client list]]
    }
 
    test "CLIENT SETNAME, CLIENT GETNAME" {


### PR DESCRIPTION
## Problem

`tests/unit/eloq/client.tcl` intermittently fails in CI's 3-node cluster **log-replay** phase with `[exception]: Executing test client: ERR No such client.` on `r client kill $addr` (observed on PR #527, run 29137305901, job `RelWithDebInfo-ELOQDSS_ELOQSTORE-arm64`). In that same job the file ran **9 times in cluster mode — 8 passed, only the log-replay run failed** — so this is a race, not a cluster incompatibility, and it is independent of that PR's changes.

## Root cause

The test opens a second connection, reads its `addr` via `CLIENT INFO`, then kills it from the `r` connection.

- `CLIENT KILL` / `CLIENT LIST` / `CLIENT INFO` and `SELECT` are all `DirectCommand`s — they execute on the connected node with no `auto_redirect` / key routing. So both connections live on node 0, and `CLIENT KILL` scans node 0's own connection map. "Target landed on another node" is ruled out; `$addr` is also stable (nothing touches the killed connection between `CLIENT INFO` and the kill).
- The actual race: a freshly accepted brpc connection can already answer **its own** commands (via the io_uring recv ring) *before* `Acceptor::OnNewConnectionsUntilEAGAIN` inserts its socket into `_socket_map` — the map that `CLIENT LIST` / `CLIENT KILL` enumerate (brpc documents this "funny race condition" in `acceptor.cpp`). When `CLIENT KILL` wins that race it matches zero sockets → `killed_ == 0` → `ERR No such client`.
- The window is sub-millisecond normally but widens under the CPU starvation of the log-replay phase (three nodes sharing `core_number=2`), which is why it flaked only there.

## Fix

EloqKV's `CLIENT KILL` only supports the old-style `addr:port` form (killing by id would need a server change), so the fix waits until the target `addr` is actually visible in `CLIENT LIST` — the *same* `_socket_map` that `CLIENT KILL` scans — before killing it. Once the addr appears, the kill is deterministic. A small `kill_client_by_addr` helper replaces the three racy `r client kill $addr` sites. This keeps cluster coverage instead of restricting the cases to single-node, and follows the same "wait on the real condition, don't sleep/race" approach as the earlier pubsub flake fix (e5ca361).

## Verification

Ran the real harness against a scratch single-node server: all four `client.tcl` tests pass, including the two later `CLIENT KILL`-by-addr sites (`CLIENT ID, CLIENT INFO, CLIENT LIST, CLIENT KILL`). No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved client connection tests by waiting for client registration before terminating connections.
  * Reduced intermittent test failures and made client removal assertions more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->