### PR TITLE
ci: drop SSH deploy key now that eloq-test is public

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -36,16 +36,10 @@ jobs:
     env:
       ELOQ_THIRD_PARTY_PREFIX: /opt/eloq/third_party
     steps:
-      - name: Bootstrap git + ssh (bare image)
+      - name: Bootstrap git (bare image)
         run: |
           apt-get update
-          # openssh-client provides ssh-agent, needed by webfactory/ssh-agent
-          # and for cloning private submodules over ssh.
-          apt-get install -y --no-install-recommends git ca-certificates sudo openssh-client
-
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          apt-get install -y --no-install-recommends git ca-certificates sudo
 
       - uses: actions/checkout@v4
         with:
@@ -54,8 +48,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
       - name: Install system dependencies
-        env:
-          GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=accept-new"
         run: |
           git config --global --add safe.directory '*'
           # System packages only; the third-party workspace is handled (cached)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,6 @@ jobs:
       LD_LIBRARY_PATH: /opt/eloq/third_party/lib
 
     steps:
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           submodules: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,6 @@ jobs:
     env:
       ELOQ_THIRD_PARTY_PREFIX: /opt/eloq/third_party
     steps:
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -73,10 +69,6 @@ jobs:
       LD_LIBRARY_PATH: /opt/eloq/third_party/lib
 
     steps:
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -84,12 +76,10 @@ jobs:
           path: eloqkv
           ref: ${{ github.event.pull_request.head.sha || '' }}
 
-      - name: Clone private dependencies
-        env:
-          GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=accept-new"
+      - name: Clone eloq-test
         run: |
           git config --global --add safe.directory '*'
-          git clone --recurse-submodules git@github.com:eloqdata/eloq-test.git eloq_test_src
+          git clone --recurse-submodules https://github.com/eloqdata/eloq-test.git eloq_test_src
 
       - name: Setup third-party (cached)
         uses: ./eloqkv/.github/actions/setup-third-party

--- a/.github/workflows/docker.eloqkv.yml
+++ b/.github/workflows/docker.eloqkv.yml
@@ -18,7 +18,7 @@ jobs:
       dockerfile: ./scripts/docker/eloqkv.docker
       image-name: eloqkv
       checkout-submodules: "false"
-      # Fetch product + third-party sources on the runner (has .git + ssh-agent);
+      # Fetch product + third-party sources on the runner (has .git);
       # the ubuntu-dev-based build stage in eloqkv.docker only compiles them.
       checkout-command: |
         bash scripts/checkout_product_submodules.sh


### PR DESCRIPTION
## What

`eloq-test` is now a **public** repo, so GitHub Actions CI no longer needs the shared eloqdata SSH deploy key (`secrets.SSH_PRIVATE_KEY`). This removes all SSH-key plumbing from `.github`.

## Changes

- **ci.yml** — remove both `webfactory/ssh-agent` steps; clone `eloq-test` over `https://` instead of `git@github.com:` (drop `GIT_SSH_COMMAND`)
- **build.yml** — remove `webfactory/ssh-agent` step
- **build-validation.yml** — remove `ssh-agent` step, drop `openssh-client` from bootstrap, drop `GIT_SSH_COMMAND`
- **docker.eloqkv.yml** — fix stale `ssh-agent` comment

## Why it's safe

- All product submodules (tx_service/data_substrate, eloqstore, brpc, braft, mimalloc, rocksdb-cloud, crcspeed) are **public** and already fetched over https via `.gitmodules` — no key needed.
- `eloq-test`, `eloqkv`, `tx_service`, `eloq-metrics` all verified public.

## Not touched

- **Concourse** pipelines/tasks are unchanged (per request).
- `gh_ci_entry.sh`'s `service ssh start` / `StrictHostKeyChecking` is the container's sshd for cluster tests, unrelated to the git deploy key — left as-is.
- `secrets: inherit` kept for Docker Hub push credentials.

After merge, the `SSH_PRIVATE_KEY` repo secret can be deleted — it's no longer referenced by any workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and validation workflows to use HTTPS-based source retrieval.
  * Removed SSH-agent setup and related private-key configuration from CI and build processes.
  * Streamlined container setup to install only the system packages required for Git operations.
  * Updated workflow documentation to reflect the simplified source-fetching process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->