### PR TITLE
build: defer nightly release swap until assets are ready

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,14 @@ on:
         type: boolean
         default: false
         description: 'mark the release as a prerelease (used by nightly)'
+      upload_release_assets:
+        type: boolean
+        default: true
+        description: 'upload packaged assets to a GitHub release'
+      upload_workflow_artifacts:
+        type: boolean
+        default: false
+        description: 'upload packaged assets as workflow artifacts'
 
 jobs:
   build:
@@ -214,6 +222,7 @@ jobs:
           done
 
       - name: Upload assets to release
+        if: ${{ inputs.upload_release_assets }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ inputs.tag_name }}
@@ -224,3 +233,14 @@ jobs:
             log-service-*-${{ inputs.arch }}.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload packaged assets as workflow artifact
+        if: ${{ inputs.upload_workflow_artifacts }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets-${{ inputs.tag_name }}-${{ inputs.arch }}
+          path: |
+            eloqkv-*-${{ inputs.arch }}.tar.gz
+            log-service-*-${{ inputs.arch }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,51 +1,34 @@
 name: Nightly
 
-# Rolling nightly build. On every push to main it resets a single `nightly`
-# prerelease at the latest commit, then builds every shipped variant on amd64 +
-# arm64 and uploads the packages to it. Assets are always available at a stable
-# URL: <repo>/releases/download/nightly/<asset>.
+# Rolling nightly build. On every push to main it builds every shipped variant
+# on amd64 + arm64 first, then replaces the single `nightly` prerelease after all
+# packages are ready. Assets are available at a stable URL:
+# <repo>/releases/download/nightly/<asset>.
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-# Only one nightly build at a time; a newer push cancels the in-flight one so
-# the nightly release always reflects the latest main.
+# Only one nightly build at a time. Do not cancel an in-flight run because the
+# final publish step briefly swaps the shared nightly release/tag.
 concurrency:
   group: nightly
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: write
 
 jobs:
-  # Serialize the destructive part (move the nightly tag + reset the release)
-  # into a single job, so the matrix jobs below only append their own
-  # uniquely-named assets and never race on the shared release/tag.
-  prepare:
-    name: Reset nightly release
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Recreate the rolling nightly prerelease at the current commit
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
-          gh release create nightly \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$GITHUB_SHA" \
-            --title "Nightly" \
-            --notes "Rolling nightly build from ${GITHUB_SHA}." \
-            --prerelease
-
   call-build:
-    needs: prepare
     name: ${{ matrix.arch }}
     uses: ./.github/workflows/build.yml
     with:
       tag_name: nightly
       prerelease: true
+      upload_release_assets: false
+      upload_workflow_artifacts: true
       arch: ${{ matrix.arch }}
       os_id: ubuntu24
       package_manager: apt
@@ -55,3 +38,63 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
+
+  publish:
+    name: Publish nightly release
+    needs: call-build
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download packaged assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-assets-nightly-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Stage complete release and switch nightly
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          assets=(release-assets/*.tar.gz)
+          expected_assets=20
+          if [ "${#assets[@]}" -ne "${expected_assets}" ]; then
+            printf 'Expected %s nightly assets, found %s:\n' "${expected_assets}" "${#assets[@]}" >&2
+            find release-assets -maxdepth 1 -type f -print | sort >&2
+            exit 1
+          fi
+
+          staging_tag="nightly-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          gh release delete "${staging_tag}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+
+          cleanup_staging() {
+            gh release delete "${staging_tag}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+          }
+          trap cleanup_staging ERR
+
+          gh release create "${staging_tag}" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Nightly staging ${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}" \
+            --notes "Staged nightly build from ${GITHUB_SHA}." \
+            --prerelease \
+            --draft
+
+          notes_file="$(mktemp)"
+          printf 'Rolling nightly build from %s.\n' "$GITHUB_SHA" > "${notes_file}"
+
+          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" >/dev/null 2>&1 || true
+          gh release edit "${staging_tag}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --tag nightly \
+            --target "$GITHUB_SHA" \
+            --title "Nightly" \
+            --notes-file "${notes_file}" \
+            --prerelease \
+            --draft=false
+
+          trap - ERR
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${staging_tag}" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Context

The rolling nightly workflow deleted and recreated the `nightly` GitHub release before building packages. During the build window, stable nightly download URLs could point at an empty or missing release, and a failed build could leave the nightly release incomplete.

## Behavior before and after

Before: `nightly.yml` deleted the existing `nightly` release/tag first, created an empty prerelease, then let the amd64 and arm64 build jobs upload assets as they completed.

After: nightly builds produce workflow artifacts first. The existing `nightly` release remains available during the build. A final publish job downloads all package artifacts, verifies that the complete 20-asset set exists, creates a fully populated staging draft release, and only then switches the public `nightly` release/tag.

## Implementation

- Added reusable workflow inputs in `build.yml` to either upload packaged assets to a release or upload them as workflow artifacts.
- Changed `nightly.yml` to call `build.yml` in artifact mode for both architectures.
- Added a publish job that downloads packaged artifacts, validates the expected asset count, stages the complete release under a run-specific tag, then renames that release to `nightly`.

## Design decisions and alternatives

The workflow stages assets in a draft release before touching the stable `nightly` tag so the long build and upload window does not affect existing downloads. The final release/tag swap is still a short GitHub Release update window, but it is no longer tied to the full build duration.

`cancel-in-progress` is disabled so an already publishing run is not interrupted while mutating the shared `nightly` release. Newer pushes queue behind the active run and then publish their own nightly result.

## Test plan

- [ ] Unit/TCL tests
- [x] Integration or manual validation
- [x] Formatting/build checks
- [x] Compatibility or performance validation, when relevant

Commands and results:

```text
git diff --check HEAD~1 HEAD
# passed

python3 -c 'import yaml, sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print("ok")' .github/workflows/build.yml .github/workflows/nightly.yml
# ok

which actionlint
# not installed in this workspace; actionlint was not run
```

No C++ build or TCL tests were run because this change only touches GitHub Actions workflow YAML.

## Risk assessment

The main risk is GitHub Release API behavior around retagging the staging draft release to `nightly`. The workflow reduces the long unavailable window, but reviewers should confirm the final `gh release edit --tag nightly --draft=false` behavior in GitHub Actions.

Another operational tradeoff is that an older in-flight nightly run can finish before a newer queued run starts; the newer run should then publish the latest commit afterward.

## Rollback plan

Revert this PR to restore the previous delete-create-upload nightly flow.

## Reviewer guide

Start with `.github/workflows/nightly.yml`, especially the new `publish` job and the release/tag swap sequence. Then review `.github/workflows/build.yml` to confirm release builds still default to direct release uploads while nightly opts into workflow artifacts.

## Follow-up work

Consider adding `actionlint` to CI or developer tooling so workflow syntax and GitHub Actions semantics are checked automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional workflow artifact uploads for packaged build files, retained for seven days.
  * Added controls to enable or disable release asset and workflow artifact uploads.

* **Improvements**
  * Nightly releases are now published through a dedicated process after all builds complete.
  * Nightly publishing validates that all expected packages are available before creating the release.
  * Improved failure handling and cleanup during nightly release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->