### PR TITLE
Parallelize nightly and release variant builds

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -352,6 +352,66 @@ function dump_eloq_test_focused_logs() {
   dump_file_tail "$runtime_dir/node6_log" 250
 }
 
+function ensure_gdb_available() {
+  if ! command -v gdb >/dev/null 2>&1; then
+    echo "gdb not installed; installing..."
+    (apt-get update && apt-get install -y gdb) >/dev/null 2>&1 || true
+  fi
+  command -v gdb >/dev/null 2>&1
+}
+
+function dump_live_process_backtraces() {
+  # Timeout failures leave the process alive, so core dumps are not enough to
+  # diagnose where the server is stuck.
+  set +e
+  echo ""
+  echo "===== live process backtraces ====="
+
+  if ! ensure_gdb_available; then
+    echo "gdb unavailable; cannot attach to live processes."
+    return 0
+  fi
+
+  local pids
+  pids=$(ps -eo pid=,comm= | awk '$2 == "eloqkv" || $2 == "dss_server" || $2 == "launch_sv" {print $1}' | head -12)
+
+  if [ -z "$pids" ]; then
+    echo "No live eloqkv, dss_server, or launch_sv processes found."
+    return 0
+  fi
+
+  local pid comm args exe
+  for pid in $pids; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      continue
+    fi
+
+    comm=$(ps -p "$pid" -o comm= 2>/dev/null)
+    args=$(ps -p "$pid" -o args= 2>/dev/null)
+    exe=$(readlink -f "/proc/${pid}/exe" 2>/dev/null || true)
+
+    echo ""
+    echo "----- live backtrace for pid ${pid} (${comm:-unknown}) -----"
+    echo "args: ${args:-<unknown>}"
+    echo "exe: ${exe:-<unknown>}"
+
+    if command -v timeout >/dev/null 2>&1; then
+      timeout 30s gdb -q -batch -nx \
+        -p "$pid" \
+        -ex 'set pagination off' \
+        -ex 'thread apply all bt' \
+        -ex 'detach' 2>&1 | head -800 || true
+    else
+      gdb -q -batch -nx \
+        -p "$pid" \
+        -ex 'set pagination off' \
+        -ex 'thread apply all bt' \
+        -ex 'detach' 2>&1 | head -800 || true
+    fi
+  done
+  echo "===== end live process backtraces ====="
+}
+
 function dump_core_backtraces() {
   # Print a full backtrace for every core dump we can find. Requires the
   # core_pattern to write a real file (set in gh_ci_entry.sh on the privileged
@@ -360,11 +420,7 @@ function dump_core_backtraces() {
   echo ""
   echo "===== core dump backtraces ====="
 
-  if ! command -v gdb >/dev/null 2>&1; then
-    echo "gdb not installed; installing..."
-    (apt-get update && apt-get install -y gdb) >/dev/null 2>&1 || true
-  fi
-  if ! command -v gdb >/dev/null 2>&1; then
+  if ! ensure_gdb_available; then
     echo "gdb unavailable; cannot symbolize cores. core_pattern=$(cat /proc/sys/kernel/core_pattern 2>/dev/null)"
     return 0
   fi
@@ -434,11 +490,12 @@ function dump_ci_failure_logs() {
   date || true
   pwd || true
 
-  dump_core_backtraces
-
   echo ""
   echo "===== Running eloq-related processes ====="
   ps -ef | grep -E 'eloqkv|dss_server|launch_sv|minio|redis-server' | grep -v grep || true
+
+  dump_live_process_backtraces
+  dump_core_backtraces
 
   echo ""
   echo "===== eloq_test runtime files ====="

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1086,6 +1086,8 @@ function run_eloqkv_tests() {
     # Wait for Redis server to be ready
     wait_until_ready
     echo "Redis server is ready!" >>/tmp/redis_single_node.log
+    echo "Flushing replayed data before Tcl tests." >>/tmp/redis_single_node.log
+    redis-cli -h 127.0.0.1 -p 6379 flushall
 
     run_tcl_tests all $build_type
     echo "finished big ckpt interval before replay with wal and data store." >>/tmp/redis_single_node.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build
 
-# One job per architecture: build the third-party workspace from source ONCE,
-# then build, package and upload every shipped variant. This avoids rebuilding
-# third-party for each variant (was 5x per arch). Slower wall-clock per job but
-# far less total compute; release/nightly are not latency-sensitive.
+# One job per architecture and shipped variant. This spends more total runner
+# time than building all variants serially per architecture, but release/nightly
+# wall-clock time is dominated by the slowest variant instead of the sum of all
+# variants.
 
 on:
   workflow_call:
@@ -11,6 +11,14 @@ on:
       tag_name:
         type: string
         required: true
+      release_tag_name:
+        type: string
+        default: ''
+        description: 'release tag to upload assets to; defaults to tag_name'
+      release_draft:
+        type: boolean
+        default: false
+        description: 'upload assets to a draft release'
       os_id:
         type: string
         default: ubuntu24
@@ -41,10 +49,44 @@ on:
 jobs:
   build:
     runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: rocksdb
+            data_store: ROCKSDB
+            log_state: ROCKSDB
+            build_dss: "false"
+            build_rocksdb_tools: "true"
+            cmake_extra: ""
+          - id: rocks_s3
+            data_store: ELOQDSS_ROCKSDB_CLOUD_S3
+            log_state: ROCKSDB_CLOUD_S3
+            build_dss: "true"
+            build_rocksdb_tools: "true"
+            cmake_extra: -DWITH_CLOUD_AZ_INFO=ON
+          - id: eloqstore_local
+            data_store: ELOQDSS_ELOQSTORE
+            log_state: ROCKSDB
+            build_dss: "true"
+            build_rocksdb_tools: "false"
+            cmake_extra: ""
+          - id: eloqstore_s3
+            data_store: ELOQDSS_ELOQSTORE
+            log_state: ROCKSDB_CLOUD_S3
+            build_dss: "true"
+            build_rocksdb_tools: "false"
+            cmake_extra: -DWITH_CLOUD_AZ_INFO=ON
+          - id: eloqstore_gcs
+            data_store: ELOQDSS_ELOQSTORE
+            log_state: ROCKSDB_CLOUD_GCS
+            build_dss: "true"
+            build_rocksdb_tools: "false"
+            cmake_extra: ""
     container:
       image: ${{ inputs.container_image }}
       options: --user root
-    name: ${{ inputs.tag_name }}-${{ inputs.arch }}
+    name: ${{ inputs.tag_name }}-${{ inputs.arch }}-${{ matrix.id }}
     # In the container the default run shell is `sh` (dash); force bash so the
     # packaging step's arrays / here-strings / `set -o pipefail` work.
     defaults:
@@ -54,6 +96,12 @@ jobs:
       TAGGED: ${{ inputs.tag_name }}
       ARCH: ${{ inputs.arch }}
       OS_ID: ${{ inputs.os_id }}
+      VARIANT_ID: ${{ matrix.id }}
+      WITH_DATA_STORE_VALUE: ${{ matrix.data_store }}
+      WITH_LOG_STATE_VALUE: ${{ matrix.log_state }}
+      BUILD_DSS: ${{ matrix.build_dss }}
+      BUILD_ROCKSDB_TOOLS: ${{ matrix.build_rocksdb_tools }}
+      CMAKE_EXTRA: ${{ matrix.cmake_extra }}
       ELOQ_THIRD_PARTY_PREFIX: /opt/eloq/third_party
       CMAKE_PREFIX_PATH: /opt/eloq/third_party
       CMAKE_INCLUDE_PATH: /opt/eloq/third_party/include
@@ -95,19 +143,10 @@ jobs:
             yum) yum install -y postgresql-devel rsync patchelf ;;
           esac
 
-      - name: Build and package all variants
+      - name: Build and package variant
         working-directory: ${{ github.workspace }}/eloqkv_src
         run: |
           set -euo pipefail
-
-          # id | WITH_DATA_STORE | WITH_LOG_STATE | build_dss | build_rocksdb_tools | cmake_extra
-          VARIANTS=(
-            "rocksdb|ROCKSDB|ROCKSDB|false|true|"
-            "rocks_s3|ELOQDSS_ROCKSDB_CLOUD_S3|ROCKSDB_CLOUD_S3|true|true|-DWITH_CLOUD_AZ_INFO=ON"
-            "eloqstore_local|ELOQDSS_ELOQSTORE|ROCKSDB|true|false|"
-            "eloqstore_s3|ELOQDSS_ELOQSTORE|ROCKSDB_CLOUD_S3|true|false|"
-            "eloqstore_gcs|ELOQDSS_ELOQSTORE|ROCKSDB_CLOUD_GCS|true|false|"
-          )
 
           write_license() {
             printf '%s\n' \
@@ -144,86 +183,94 @@ jobs:
             done
           }
 
-          for entry in "${VARIANTS[@]}"; do
-            IFS='|' read -r id dst lst dss rtools extra <<< "$entry"
-            echo "::group::Build variant ${id} (${ARCH})"
+          id="${VARIANT_ID}"
+          dst="${WITH_DATA_STORE_VALUE}"
+          lst="${WITH_LOG_STATE_VALUE}"
+          dss="${BUILD_DSS}"
+          rtools="${BUILD_ROCKSDB_TOOLS}"
+          extra="${CMAKE_EXTRA}"
+          echo "::group::Build variant ${id} (${ARCH})"
 
-            # --- eloqkv ---
-            rm -rf build
-            # shellcheck disable=SC2086
-            cmake -S . -B build \
+          # --- eloqkv ---
+          rm -rf build
+          # shellcheck disable=SC2086
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DWITH_DATA_STORE="${dst}" \
+            -DWITH_LOG_STATE="${lst}" \
+            -DWITH_LOG_SERVICE=ON \
+            -DDISABLE_CKPT_REPORT=ON \
+            -DDISABLE_CODE_LINE_IN_LOG=ON \
+            -DWITH_ASAN=OFF \
+            -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
+            -DELOQ_THIRD_PARTY_REQUIRED=ON \
+            ${extra}
+          cmake --build build -j"$(nproc)"
+
+          DEST_DIR="$HOME/EloqKV"
+          rm -rf "$DEST_DIR"
+          mkdir -p "$DEST_DIR/bin" "$DEST_DIR/lib" "$DEST_DIR/conf"
+          cp build/eloqkv "$DEST_DIR/bin/"
+          cp build/data_substrate/host_manager "$DEST_DIR/bin/"
+
+          if [ "${rtools}" = "true" ]; then
+            for tool in eloqkv_to_aof eloqkv_to_rdb; do
+              if [ -x "build/$tool" ]; then
+                cp "build/$tool" "$DEST_DIR/bin/"
+              else
+                echo "skip $tool (not built for ${dst})"
+              fi
+            done
+          fi
+
+          if [ "${dss}" = "true" ]; then
+            DSS_SRC="$PWD/data_substrate/store_handler/eloq_data_store_service"
+            rm -rf "$DSS_SRC/build"
+            cmake -S "$DSS_SRC" -B "$DSS_SRC/build" \
               -DCMAKE_BUILD_TYPE=RelWithDebInfo \
               -DWITH_DATA_STORE="${dst}" \
-              -DWITH_LOG_STATE="${lst}" \
-              -DWITH_LOG_SERVICE=ON \
-              -DDISABLE_CKPT_REPORT=ON \
-              -DDISABLE_CODE_LINE_IN_LOG=ON \
-              -DWITH_ASAN=OFF \
               -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
-              -DELOQ_THIRD_PARTY_REQUIRED=ON \
-              ${extra}
-            cmake --build build -j"$(nproc)"
+              -DELOQ_THIRD_PARTY_REQUIRED=ON
+            cmake --build "$DSS_SRC/build" -j"$(nproc)"
+            cp "$DSS_SRC/build/dss_server" "$DEST_DIR/bin/"
+          fi
 
-            DEST_DIR="$HOME/EloqKV"
-            rm -rf "$DEST_DIR"
-            mkdir -p "$DEST_DIR/bin" "$DEST_DIR/lib" "$DEST_DIR/conf"
-            cp build/eloqkv "$DEST_DIR/bin/"
-            cp build/data_substrate/host_manager "$DEST_DIR/bin/"
+          for bin in "$DEST_DIR"/bin/*; do bundle_libs "$bin" "$DEST_DIR/lib"; done
+          find "$DEST_DIR/lib" \
+            \( -name 'libbrpc*' -o -name 'libbraft*' -o -name 'libleveldb*' -o -name 'librocksdb*' \) \
+            -exec patchelf --set-rpath '$ORIGIN' {} \; 2>/dev/null || true
+          cp eloqkv.ini "$DEST_DIR/conf/"
+          write_license "$DEST_DIR/LICENSE.txt"
+          tar -czf "$GITHUB_WORKSPACE/eloqkv-${TAGGED}-${id}-${OS_ID}-${ARCH}.tar.gz" -C "$HOME" EloqKV
 
-            if [ "${rtools}" = "true" ]; then
-              for tool in eloqkv_to_aof eloqkv_to_rdb; do
-                [ -x "build/$tool" ] && cp "build/$tool" "$DEST_DIR/bin/" || echo "skip $tool (not built for ${dst})"
-              done
-            fi
+          # --- log-service ---
+          LOG_SRC="$PWD/data_substrate/eloq_log_service"
+          rm -rf "$LOG_SRC/build" "$LOG_SRC/LogServer"
+          mkdir -p "$LOG_SRC/LogServer/bin" "$LOG_SRC/LogServer/lib"
+          # shellcheck disable=SC2086
+          cmake -S "$LOG_SRC" -B "$LOG_SRC/build" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DWITH_LOG_STATE="${lst}" \
+            -DWITH_ASAN=OFF \
+            -DDISABLE_CODE_LINE_IN_LOG=ON \
+            -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
+            -DELOQ_THIRD_PARTY_REQUIRED=ON \
+            ${extra}
+          cmake --build "$LOG_SRC/build" -j"$(nproc)"
+          mv "$LOG_SRC/build/launch_sv" "$LOG_SRC/LogServer/bin/"
+          bundle_libs "$LOG_SRC/LogServer/bin/launch_sv" "$LOG_SRC/LogServer/lib"
+          tar -czf "$GITHUB_WORKSPACE/log-service-${TAGGED}-${id}-${OS_ID}-${ARCH}.tar.gz" -C "$LOG_SRC" LogServer
 
-            if [ "${dss}" = "true" ]; then
-              DSS_SRC="$PWD/data_substrate/store_handler/eloq_data_store_service"
-              rm -rf "$DSS_SRC/build"
-              cmake -S "$DSS_SRC" -B "$DSS_SRC/build" \
-                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-                -DWITH_DATA_STORE="${dst}" \
-                -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
-                -DELOQ_THIRD_PARTY_REQUIRED=ON
-              cmake --build "$DSS_SRC/build" -j"$(nproc)"
-              cp "$DSS_SRC/build/dss_server" "$DEST_DIR/bin/"
-            fi
-
-            for bin in "$DEST_DIR"/bin/*; do bundle_libs "$bin" "$DEST_DIR/lib"; done
-            find "$DEST_DIR/lib" \
-              \( -name 'libbrpc*' -o -name 'libbraft*' -o -name 'libleveldb*' -o -name 'librocksdb*' \) \
-              -exec patchelf --set-rpath '$ORIGIN' {} \; 2>/dev/null || true
-            cp eloqkv.ini "$DEST_DIR/conf/"
-            write_license "$DEST_DIR/LICENSE.txt"
-            tar -czf "$GITHUB_WORKSPACE/eloqkv-${TAGGED}-${id}-${OS_ID}-${ARCH}.tar.gz" -C "$HOME" EloqKV
-
-            # --- log-service ---
-            LOG_SRC="$PWD/data_substrate/eloq_log_service"
-            rm -rf "$LOG_SRC/build" "$LOG_SRC/LogServer"
-            mkdir -p "$LOG_SRC/LogServer/bin" "$LOG_SRC/LogServer/lib"
-            # shellcheck disable=SC2086
-            cmake -S "$LOG_SRC" -B "$LOG_SRC/build" \
-              -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-              -DWITH_LOG_STATE="${lst}" \
-              -DWITH_ASAN=OFF \
-              -DDISABLE_CODE_LINE_IN_LOG=ON \
-              -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party \
-              -DELOQ_THIRD_PARTY_REQUIRED=ON \
-              ${extra}
-            cmake --build "$LOG_SRC/build" -j"$(nproc)"
-            mv "$LOG_SRC/build/launch_sv" "$LOG_SRC/LogServer/bin/"
-            bundle_libs "$LOG_SRC/LogServer/bin/launch_sv" "$LOG_SRC/LogServer/lib"
-            tar -czf "$GITHUB_WORKSPACE/log-service-${TAGGED}-${id}-${OS_ID}-${ARCH}.tar.gz" -C "$LOG_SRC" LogServer
-
-            echo "::endgroup::"
-          done
+          echo "::endgroup::"
 
       - name: Upload assets to release
         if: ${{ inputs.upload_release_assets }}
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ inputs.tag_name }}
-          name: ${{ inputs.tag_name }}
+          tag_name: ${{ inputs.release_tag_name || inputs.tag_name }}
+          name: ${{ inputs.release_tag_name || inputs.tag_name }}
           prerelease: ${{ inputs.prerelease }}
+          draft: ${{ inputs.release_draft }}
           files: |
             eloqkv-*-${{ inputs.arch }}.tar.gz
             log-service-*-${{ inputs.arch }}.tar.gz
@@ -234,7 +281,7 @@ jobs:
         if: ${{ inputs.upload_workflow_artifacts }}
         uses: actions/upload-artifact@v4
         with:
-          name: release-assets-${{ inputs.tag_name }}-${{ inputs.arch }}
+          name: release-assets-${{ inputs.tag_name }}-${{ inputs.arch }}-${{ matrix.id }}
           path: |
             eloqkv-*-${{ inputs.arch }}.tar.gz
             log-service-*-${{ inputs.arch }}.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,8 @@
 name: Nightly
 
-# Rolling nightly build. On every push to main it builds every shipped variant
-# on amd64 + arm64 first, then replaces the single `nightly` prerelease after all
+# Rolling nightly build. On every push to main it stages a run-specific release,
+# builds every shipped variant on amd64 + arm64, uploads packages to that staging
+# release in parallel, then replaces the single `nightly` prerelease after all
 # packages are ready. Assets are available at a stable URL:
 # <repo>/releases/download/nightly/<asset>.
 
@@ -21,14 +22,43 @@ permissions:
   contents: write
 
 jobs:
+  prepare:
+    name: Create staging release
+    runs-on: ubuntu-24.04
+    outputs:
+      staging_tag: ${{ steps.staging.outputs.tag }}
+    steps:
+      - name: Create run-specific staging prerelease
+        id: staging
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Keep the temporary tag outside any nightly tag protection/ruleset.
+          staging_tag="release-staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "tag=${staging_tag}" >> "$GITHUB_OUTPUT"
+
+          gh release delete "${staging_tag}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+          gh release create "${staging_tag}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Nightly staging ${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}" \
+            --notes "Staged nightly build from ${GITHUB_SHA}." \
+            --prerelease \
+            --draft
+
   call-build:
+    needs: prepare
     name: ${{ matrix.arch }}
     uses: ./.github/workflows/build.yml
     with:
       tag_name: nightly
+      release_tag_name: ${{ needs.prepare.outputs.staging_tag }}
       prerelease: true
-      upload_release_assets: false
-      upload_workflow_artifacts: true
+      release_draft: true
+      upload_release_assets: true
+      upload_workflow_artifacts: false
       arch: ${{ matrix.arch }}
       os_id: ubuntu24
       package_manager: apt
@@ -41,53 +71,48 @@ jobs:
 
   publish:
     name: Publish nightly release
-    needs: call-build
+    needs: [prepare, call-build]
+    if: ${{ always() && needs.prepare.result == 'success' }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Download packaged assets
-        uses: actions/download-artifact@v4
-        with:
-          pattern: release-assets-nightly-*
-          path: release-assets
-          merge-multiple: true
-
-      - name: Stage complete release and switch nightly
+      - name: Cleanup staging release after failed build
+        if: ${{ needs.call-build.result != 'success' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STAGING_TAG: ${{ needs.prepare.outputs.staging_tag }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
+          gh release delete "${STAGING_TAG}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
+          exit 1
 
-          assets=(release-assets/*.tar.gz)
-          expected_assets=20
-          if [ "${#assets[@]}" -ne "${expected_assets}" ]; then
-            printf 'Expected %s nightly assets, found %s:\n' "${expected_assets}" "${#assets[@]}" >&2
-            find release-assets -maxdepth 1 -type f -print | sort >&2
-            exit 1
-          fi
-
-          staging_tag="nightly-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          gh release delete "${staging_tag}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+      - name: Verify staged assets and switch nightly
+        if: ${{ needs.call-build.result == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STAGING_TAG: ${{ needs.prepare.outputs.staging_tag }}
+        run: |
+          set -euo pipefail
 
           cleanup_staging() {
-            gh release delete "${staging_tag}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
+            gh release delete "${STAGING_TAG}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 || true
           }
           trap cleanup_staging ERR
 
-          gh release create "${staging_tag}" "${assets[@]}" \
-            --repo "$GITHUB_REPOSITORY" \
-            --target "$GITHUB_SHA" \
-            --title "Nightly staging ${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}" \
-            --notes "Staged nightly build from ${GITHUB_SHA}." \
-            --prerelease \
-            --draft
+          asset_count="$(gh release view "${STAGING_TAG}" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets | length')"
+          expected_assets=20
+          if [ "${asset_count}" -ne "${expected_assets}" ]; then
+            printf 'Expected %s nightly assets, found %s:\n' "${expected_assets}" "${asset_count}" >&2
+            gh release view "${STAGING_TAG}" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' >&2
+            cleanup_staging
+            exit 1
+          fi
 
           notes_file="$(mktemp)"
           printf 'Rolling nightly build from %s.\n' "$GITHUB_SHA" > "${notes_file}"
 
           gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
           gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" >/dev/null 2>&1 || true
-          gh release edit "${staging_tag}" \
+          gh release edit "${STAGING_TAG}" \
             --repo "$GITHUB_REPOSITORY" \
             --tag nightly \
             --target "$GITHUB_SHA" \
@@ -97,4 +122,15 @@ jobs:
             --draft=false
 
           trap - ERR
-          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${staging_tag}" >/dev/null 2>&1 || true
+          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${STAGING_TAG}" >/dev/null 2>&1 || true
+
+          if stale_tags="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[] | select(.draft == true and (.tag_name | startswith("release-staging-"))) | .tag_name' 2>/dev/null)"; then
+            while IFS= read -r stale_tag; do
+              [ -n "${stale_tag}" ] || continue
+              echo "Deleting stale nightly staging draft ${stale_tag}"
+              gh release delete "${stale_tag}" --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
+            done <<< "${stale_tags}"
+          else
+            echo "Skipping stale nightly staging draft cleanup; unable to list releases."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,40 @@ on:
         type: string
 
 jobs:
-  # One job per arch; build.yml builds third-party once and then all variants.
+  prepare:
+    name: Create release
+    runs-on: ubuntu-24.04
+    outputs:
+      release_created: ${{ steps.release.outputs.created }}
+    steps:
+      - name: Create or reuse release
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.inputs.tag_name || github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh release create "${RELEASE_TAG}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "${RELEASE_TAG}" \
+            --notes "Release ${RELEASE_TAG}." \
+            --draft
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+  # build.yml expands each architecture into the shipped variant matrix.
   call-build:
+    needs: prepare
     name: ${{ matrix.arch }}
     uses: ./.github/workflows/build.yml
     with:
       tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+      release_draft: true
       arch: ${{ matrix.arch }}
       os_id: ubuntu24
       package_manager: apt
@@ -32,3 +60,27 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
+
+  publish:
+    name: Publish release
+    needs: [prepare, call-build]
+    if: ${{ always() && needs.prepare.result == 'success' }}
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ github.event.inputs.tag_name || github.ref_name }}
+    steps:
+      - name: Delete draft release after failed build
+        if: ${{ needs.call-build.result != 'success' }}
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.prepare.outputs.release_created }}" = "true" ]; then
+            gh release delete "${RELEASE_TAG}" --yes --repo "$GITHUB_REPOSITORY" || true
+          fi
+          exit 1
+
+      - name: Publish completed release
+        if: ${{ needs.call-build.result == 'success' }}
+        run: |
+          set -euo pipefail
+          gh release edit "${RELEASE_TAG}" --repo "$GITHUB_REPOSITORY" --draft=false


### PR DESCRIPTION
## Context

The first nightly run after #541 failed in the final publish step:

```text
HTTP 403: Resource not accessible by integration (https://api.github.com/repos/eloqdata/eloqkv/releases)
```

That failure happened while the temporary staging tag was named `nightly-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`.

The fork smoke run also showed that moving all release uploads into one final `gh release create ... "${assets[@]}"` step is too slow for the current package set: the publish job spent hours uploading release assets serially after both architecture builds had already finished.

## Behavior before and after

Before: nightly builds uploaded architecture packages as workflow artifacts, then a single publish job downloaded all 20 tarballs and uploaded them to a staging draft release before switching `nightly`. Each architecture job also built all five shipped variants serially.

After: the workflow creates a run-specific staging draft release first, then build jobs upload package assets directly to that staging release. `build.yml` now expands each architecture into the five shipped variants, so release/nightly runs can execute the full `2 arch x 5 variant` set concurrently. The final publish job only verifies that all 20 assets are present and then switches the staging release to the stable `nightly` tag.

The final public nightly release tag remains `nightly`. Nightly concurrency behavior is unchanged: one nightly workflow runs at a time, an already-running workflow is allowed to finish, and GitHub replaces the single pending run when newer main pushes arrive.

## Implementation

- Added `release_tag_name` and `release_draft` inputs to `.github/workflows/build.yml` so package naming can remain `nightly` while uploads target a run-specific staging release.
- Changed `build.yml` from one job per architecture with a shell loop over variants to a job matrix over the five shipped variants.
- Matched the release script's cloud option for `eloqstore_s3` by passing `-DWITH_CLOUD_AZ_INFO=ON`.
- Made Redis export tool copies fail on `cp` errors instead of reporting those failures as skipped tools.
- Added a `prepare` job in `.github/workflows/nightly.yml` that creates `release-staging-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` as a draft prerelease.
- Changed nightly build jobs to upload release assets directly to the staging release instead of workflow artifacts.
- Changed the final nightly publish job to clean up staging on build failure, verify the expected 20 assets, clean up staging on verification failure, retag/publish the staging release as `nightly`, and best-effort delete older `release-staging-*` draft releases after success.
- Changed normal releases to create a draft first, upload assets into the draft, and publish only after all matrix builds succeed. The failure cleanup only deletes drafts created by the current run, so pre-existing releases are not removed.

## Design decisions and alternatives

This keeps the old `nightly` release available during build and upload, restores parallel release uploads, and increases build parallelism across variants. It spends more total runner time than serial per-architecture builds, but reduces wall-clock time for release/nightly.

The staging tag avoids the `nightly-` prefix so it does not match nightly-specific tag protection or rulesets.

The final nightly swap still has a short non-atomic GitHub Release retag window because GitHub does not allow two releases with the same `nightly` tag. Avoiding that completely would require a different promotion model, such as re-uploading/replacing assets on the stable release.

## Test plan

- [ ] Unit/TCL tests
- [x] Integration or manual validation
- [x] Formatting/build checks
- [x] Compatibility or performance validation, when relevant

Commands and results:

```text
git diff --check HEAD~1 HEAD
# passed

python3 -c 'import yaml, sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print("ok")' .github/workflows/build.yml .github/workflows/nightly.yml .github/workflows/release.yml
# ok
```

No C++ build or TCL tests were run because this only changes GitHub Actions workflow YAML. `actionlint` is not installed in this workspace, so it was not run.

## Risk assessment

Code risk is limited to GitHub Actions workflow behavior. Operational risks are higher runner usage, possible GitHub runner concurrency limits, and GitHub Release API behavior when several variant jobs upload assets to the same existing draft release.

## Rollback plan

Revert this PR.

## Reviewer guide

Review `.github/workflows/build.yml` for the new variant matrix and upload-target inputs, `.github/workflows/nightly.yml` for the staging lifecycle and final release switch, and `.github/workflows/release.yml` for draft release publication.

## Follow-up work

Pinning the build container by digest would be useful supply-chain hardening, but is intentionally left out of this workflow fix.
