### PR TITLE
Fix CI state leakage and CC request lifetime races

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -236,6 +236,26 @@ function run_tcl_tests() {
   done
 }
 
+function flush_redis_data() {
+  local log_file=$1
+  shift
+  local ports=("$@")
+
+  if [[ ${#ports[@]} -eq 0 ]]; then
+    ports=(6379)
+  fi
+
+  echo "Flushing Redis data on ports: ${ports[*]}" >>"${log_file}"
+
+  local port
+  for port in "${ports[@]}"; do
+    if ! redis-cli -h 127.0.0.1 -p "${port}" flushall; then
+      echo "Failed to flush Redis data on port ${port}." >&2
+      return 1
+    fi
+  done
+}
+
 function cleanup_minio_bucket() {
   bucket_name=$1
   if [[ "$bucket_name" == eloqkv-* ]]; then
@@ -1144,7 +1164,7 @@ function run_eloqkv_tests() {
     wait_until_ready
     echo "Redis server is ready!" >>/tmp/redis_single_node.log
     echo "Flushing replayed data before Tcl tests." >>/tmp/redis_single_node.log
-    redis-cli -h 127.0.0.1 -p 6379 flushall
+    flush_redis_data /tmp/redis_single_node.log 6379 || exit 1
 
     run_tcl_tests all $build_type
     echo "finished big ckpt interval before replay with wal and data store." >>/tmp/redis_single_node.log
@@ -1288,6 +1308,7 @@ function run_eloqkv_tests() {
     # Wait for Redis server to be ready
     wait_until_ready
     echo "Redis server is ready!" >>/tmp/redis_single_node.log
+    flush_redis_data /tmp/redis_single_node.log 6379 || exit 1
 
     run_tcl_tests all $build_type
 
@@ -1340,6 +1361,7 @@ function run_eloqkv_tests() {
     # Wait for Redis server to be ready
     wait_until_ready
     echo "Redis server is ready!" >>/tmp/redis_single_node.log
+    flush_redis_data /tmp/redis_single_node.log 6379 || exit 1
 
     run_tcl_tests all $build_type false true
     echo "finished small ckpt interval without wal and with data store." >>/tmp/redis_single_node.log
@@ -2176,6 +2198,7 @@ function run_eloqkv_cluster_tests() {
     # Wait for Redis server to be ready
     wait_until_ready
     echo "Redis server is ready!" >>/tmp/redis_cluster_with_eloqstore.log
+    flush_redis_data /tmp/redis_cluster_with_eloqstore.log "${ports[@]}" || exit 1
 
     run_tcl_tests all $build_type true true
 
@@ -2279,6 +2302,7 @@ function run_eloqkv_cluster_tests() {
     echo "Redis server is ready!" >>/tmp/redis_cluster_with_eloqstore.log
 
     # wait for redis servers to be ready
+    flush_redis_data /tmp/redis_cluster_with_eloqstore.log "${ports[@]}" || exit 1
     run_tcl_tests all $build_type true
 
     # kill redis servers
@@ -2400,6 +2424,7 @@ function run_eloqkv_cluster_tests() {
     # Wait for Redis server to be ready
     wait_until_ready
     echo "Redis server is ready!" >>/tmp/redis_cluster_with_eloqstore.log
+    flush_redis_data /tmp/redis_cluster_with_eloqstore.log "${ports[@]}" || exit 1
 
     run_tcl_tests all $build_type true
 

--- a/tests/support/server.tcl
+++ b/tests/support/server.tcl
@@ -363,7 +363,7 @@ proc run_external_server_test {code overrides} {
         }
     }
 
-    # r flushall
+    r flushall
     # r function flush
 
     # store overrides


### PR DESCRIPTION
## Context

This PR addresses the two issues found while debugging the failing `main` CI run `29401455092`.

1. The Tcl phases reused a live server that could still contain data from an earlier phase. That made `scripting.tcl` see stale keyspace state instead of a clean Redis database.
2. The crash was a real `data_substrate` lifetime race in stack-owned CC requests. The submodule update points at eloqdata/tx_service#529.

The CC crash root cause is that `CcShard::ProcessRequests()` still owns a raw request pointer after `Execute()` signals the result waiter. For stack-owned requests, the waiter can reuse or destroy the stack object before `ProcessRequests()` gets back to its final `req->Free()` call.

## Behavior before and after

Before:

- Some single-node and cluster Tcl phases ran without a `flushall` after startup, so state could leak across phases.
- Stack `KickoutCcEntryCc` request owners waited only for logical completion, not for the CC scheduler's final access to the request object.
- Stack range upload error paths could wake their waiter and still ask the scheduler to free/recycle the request.

After:

- The CI script flushes Redis data on the active single-node or cluster ports before each Tcl phase covered by this script.
- Stack `KickoutCcEntryCc` callers wait until scheduler-side `Free()` has completed before resetting the stack request.
- Stack range upload error/abort paths complete their waiter without returning `true` to the scheduler or calling `Free()`.

Compatibility: runtime behavior should be unchanged outside the cleanup boundary and the corrected stack-request lifetime paths.

## Implementation

- Added `flush_redis_data()` in `.github/scripts/common.sh` and call it before the affected single-node and cluster Tcl test phases.
- Updated `data_substrate` from `f7e62c5` to `2ef3762`:
  - `LocalCcShards::PurgeDeletedData()` and `KickoutDataForTest()` now use the existing `Use()` / `InUse()` request flag as a stack-object lifetime fence.
  - `UploadRangeSlicesCc` and `UploadBatchSlicesCc` stack-owned error paths return `false` / avoid `Free()` after waking their waiter.
  - Concurrency-control docs now spell out the stack-owned versus pool-owned request lifetime rule.

## Design decisions and alternatives

The CC fix is local to the unsafe stack-owned requests rather than changing the generic scheduler contract. It reuses the existing request `in_use_` flag and waits outside `Execute()` with `bthread_usleep()` backoff, so it does not add blocking or yield behavior to the CC execution path.

The CI cleanup is centralized in one shell helper so each phase fails fast if `flushall` cannot be applied to the expected port set.

## Test plan

- [ ] Unit/TCL tests
- [ ] Integration or manual validation
- [x] Formatting/build checks
- [ ] Compatibility or performance validation, when relevant

Commands and results:

```text
git -C data_substrate diff --check
# passed

git diff --check
# passed

cmake --build bld-verify --target txservice -j4
# passed: [100%] Built target txservice

clang-format-18 --version
# failed: clang-format-18 not installed in this workspace
```

Full Tcl/CI tests were not run locally.

## Risk assessment

The CI script now depends on `redis-cli flushall` succeeding on all listed ports before Tcl execution. That is intentional; a failed flush should fail the job rather than hiding stale state.

For the CC change, the main risk is a stack `KickoutCcEntryCc` caller waiting slightly longer after logical completion. The wait only covers the scheduler gap between result notification and `ProcessRequests()` calling `Free()`.

This PR should remain draft until eloqdata/tx_service#529 is reviewed and landed or the submodule pointer is otherwise updated to the landed commit.

## Rollback plan

Revert this PR. If only the CI cleanup needs rollback, revert the `.github/scripts/common.sh` changes while keeping the submodule update.

## Reviewer guide

- `.github/scripts/common.sh`: `flush_redis_data()` and Tcl phase call sites.
- `data_substrate` submodule diff: eloqdata/tx_service#529.

## Follow-up work

Run the full GitHub Actions matrix after the submodule PR lands and this pointer is updated if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by clearing Redis state before running both single-node and multi-port Redis scenarios.
  * Added reusable Redis flush helper to standardize cleanup across test workflows.
  * Updated workflows to stop immediately if Redis cleanup fails, preventing cascading failures.
  * Adjusted external-server test setup to begin from a clean Redis data state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->