### PR TITLE
[experiment] raise EloqStore data file size to isolate the test slowdown

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1098,7 +1098,7 @@ function run_eloqkv_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url=${txlog_rocksdb_cloud_s3_endpoint_url} \
 	      --max_processing_time_microseconds=1000 \
-	      --eloq_store_pages_per_file_shift=1 \
+	      --eloq_store_pages_per_file_shift=8 \
         --eloq_store_cloud_provider=${eloq_store_cloud_provider} \
         --eloq_store_cloud_endpoint=${eloq_store_cloud_endpoint} \
         --eloq_store_cloud_access_key=${eloq_store_cloud_access_key} \
@@ -1149,7 +1149,7 @@ function run_eloqkv_tests() {
       --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
       --txlog_rocksdb_cloud_s3_endpoint_url=${txlog_rocksdb_cloud_s3_endpoint_url} \
 	    --max_processing_time_microseconds=1000 \
-	    --eloq_store_pages_per_file_shift=1 \
+	    --eloq_store_pages_per_file_shift=8 \
       --eloq_store_cloud_provider=${eloq_store_cloud_provider} \
       --eloq_store_cloud_endpoint=${eloq_store_cloud_endpoint} \
       --eloq_store_cloud_access_key=${eloq_store_cloud_access_key} \
@@ -1210,7 +1210,7 @@ function run_eloqkv_tests() {
       --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
       --txlog_rocksdb_cloud_s3_endpoint_url=${txlog_rocksdb_cloud_s3_endpoint_url} \
 	    --max_processing_time_microseconds=1000 \
-	    --eloq_store_pages_per_file_shift=1 \
+	    --eloq_store_pages_per_file_shift=8 \
       --eloq_store_cloud_provider=${eloq_store_cloud_provider} \
       --eloq_store_cloud_endpoint=${eloq_store_cloud_endpoint} \
       --eloq_store_cloud_access_key=${eloq_store_cloud_access_key} \
@@ -1293,7 +1293,7 @@ function run_eloqkv_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url=${txlog_rocksdb_cloud_s3_endpoint_url} \
 	      --max_processing_time_microseconds=1000 \
-	      --eloq_store_pages_per_file_shift=1 \
+	      --eloq_store_pages_per_file_shift=8 \
         --eloq_store_cloud_provider=${eloq_store_cloud_provider} \
         --eloq_store_cloud_endpoint=${eloq_store_cloud_endpoint} \
         --eloq_store_cloud_access_key=${eloq_store_cloud_access_key} \
@@ -1346,7 +1346,7 @@ function run_eloqkv_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url=${txlog_rocksdb_cloud_s3_endpoint_url} \
 	      --max_processing_time_microseconds=1000 \
-	      --eloq_store_pages_per_file_shift=1 \
+	      --eloq_store_pages_per_file_shift=8 \
         --eloq_store_cloud_provider=${eloq_store_cloud_provider} \
         --eloq_store_cloud_endpoint=${eloq_store_cloud_endpoint} \
         --eloq_store_cloud_access_key=${eloq_store_cloud_access_key} \
@@ -1399,7 +1399,7 @@ function run_eloqkv_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url=${txlog_rocksdb_cloud_s3_endpoint_url} \
 	      --max_processing_time_microseconds=1000 \
-	      --eloq_store_pages_per_file_shift=1 \
+	      --eloq_store_pages_per_file_shift=8 \
         --eloq_store_cloud_provider=${eloq_store_cloud_provider} \
         --eloq_store_cloud_endpoint=${eloq_store_cloud_endpoint} \
         --eloq_store_cloud_access_key=${eloq_store_cloud_access_key} \
@@ -2137,7 +2137,7 @@ function run_eloqkv_cluster_tests() {
       --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
       --txlog_rocksdb_cloud_s3_endpoint_url="${txlog_rocksdb_cloud_s3_endpoint_url}" \
 	    --max_processing_time_microseconds=1000 \
-	    --eloq_store_pages_per_file_shift=1 \
+	    --eloq_store_pages_per_file_shift=8 \
       --eloq_store_cloud_endpoint="${txlog_rocksdb_cloud_s3_endpoint_url}" \
       --eloq_store_cloud_access_key="${rocksdb_cloud_aws_access_key_id}" \
       --eloq_store_cloud_secret_key="${rocksdb_cloud_aws_secret_access_key}" \
@@ -2182,7 +2182,7 @@ function run_eloqkv_cluster_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url="${txlog_rocksdb_cloud_s3_endpoint_url}" \
 	      --max_processing_time_microseconds=1000 \
-	      --eloq_store_pages_per_file_shift=1 \
+	      --eloq_store_pages_per_file_shift=8 \
         --eloq_store_cloud_endpoint="${txlog_rocksdb_cloud_s3_endpoint_url}" \
         --eloq_store_cloud_access_key="${rocksdb_cloud_aws_access_key_id}" \
         --eloq_store_cloud_secret_key="${rocksdb_cloud_aws_secret_access_key}" \
@@ -2244,7 +2244,7 @@ function run_eloqkv_cluster_tests() {
       --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
       --txlog_rocksdb_cloud_s3_endpoint_url="${txlog_rocksdb_cloud_s3_endpoint_url}" \
 	    --max_processing_time_microseconds=1000 \
-	    --eloq_store_pages_per_file_shift=1 \
+	    --eloq_store_pages_per_file_shift=8 \
       --eloq_store_cloud_endpoint="${txlog_rocksdb_cloud_s3_endpoint_url}" \
       --eloq_store_cloud_access_key="${rocksdb_cloud_aws_access_key_id}" \
       --eloq_store_cloud_secret_key="${rocksdb_cloud_aws_secret_access_key}" \
@@ -2284,7 +2284,7 @@ function run_eloqkv_cluster_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url="${txlog_rocksdb_cloud_s3_endpoint_url}" \
 	      --max_processing_time_microseconds=1000 \
-	      --eloq_store_pages_per_file_shift=1 \
+	      --eloq_store_pages_per_file_shift=8 \
         --eloq_store_cloud_endpoint="${txlog_rocksdb_cloud_s3_endpoint_url}" \
         --eloq_store_cloud_access_key="${rocksdb_cloud_aws_access_key_id}" \
         --eloq_store_cloud_secret_key="${rocksdb_cloud_aws_secret_access_key}" \
@@ -2364,7 +2364,7 @@ function run_eloqkv_cluster_tests() {
       --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
       --txlog_rocksdb_cloud_s3_endpoint_url="${txlog_rocksdb_cloud_s3_endpoint_url}" \
 	    --max_processing_time_microseconds=1000 \
-	    --eloq_store_pages_per_file_shift=1 \
+	    --eloq_store_pages_per_file_shift=8 \
       --eloq_store_cloud_endpoint="${txlog_rocksdb_cloud_s3_endpoint_url}" \
       --eloq_store_cloud_access_key="${rocksdb_cloud_aws_access_key_id}" \
       --eloq_store_cloud_secret_key="${rocksdb_cloud_aws_secret_access_key}" \
@@ -2408,7 +2408,7 @@ function run_eloqkv_cluster_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url="${txlog_rocksdb_cloud_s3_endpoint_url}" \
 	      --max_processing_time_microseconds=1000 \
-	      --eloq_store_pages_per_file_shift=1 \
+	      --eloq_store_pages_per_file_shift=8 \
         --eloq_store_cloud_endpoint="${txlog_rocksdb_cloud_s3_endpoint_url}" \
         --eloq_store_cloud_access_key="${rocksdb_cloud_aws_access_key_id}" \
         --eloq_store_cloud_secret_key="${rocksdb_cloud_aws_secret_access_key}" \
@@ -2477,7 +2477,7 @@ function run_eloqkv_cluster_tests() {
         --txlog_rocksdb_cloud_object_path=${txlog_rocksdb_cloud_object_path} \
         --txlog_rocksdb_cloud_s3_endpoint_url="${txlog_rocksdb_cloud_s3_endpoint_url}" \
         --max_processing_time_microseconds=1000 \
-        --eloq_store_pages_per_file_shift=1 \
+        --eloq_store_pages_per_file_shift=8 \
         --cache_evict_policy=LO_LRU \
         --lolru_large_obj_threshold_kb=1 \
         --eloq_store_cloud_endpoint="${txlog_rocksdb_cloud_s3_endpoint_url}" \

--- a/.github/scripts/gh_ci_entry.sh
+++ b/.github/scripts/gh_ci_entry.sh
@@ -17,10 +17,17 @@ source "$SCRIPT_DIR/common.sh"
 ls
 export WORKSPACE=$PWD
 
-MINIO_ENDPOINT=${1:?usage: $0 minio_endpoint minio_access_key minio_secret_key kv_store_type}
-MINIO_ACCESS_KEY=${2:?usage: $0 minio_endpoint minio_access_key minio_secret_key kv_store_type}
-MINIO_SECRET_KEY=${3:?usage: $0 minio_endpoint minio_access_key minio_secret_key kv_store_type}
-KV_STORE_TYPE=${4:?usage: $0 minio_endpoint minio_access_key minio_secret_key kv_store_type}
+USAGE="usage: $0 minio_endpoint minio_access_key minio_secret_key kv_store_type build|test"
+MINIO_ENDPOINT=${1:?$USAGE}
+MINIO_ACCESS_KEY=${2:?$USAGE}
+MINIO_SECRET_KEY=${3:?$USAGE}
+KV_STORE_TYPE=${4:?$USAGE}
+CI_PHASE=${5:?$USAGE}
+
+case "$CI_PHASE" in
+  build | test) ;;
+  *) echo "$USAGE" >&2; exit 1 ;;
+esac
 
 BUILD_TYPE=${BUILD_TYPE:?BUILD_TYPE env var not set}
 CI_MODE=${CI_MODE:-pr}             # "pr" or "main"
@@ -60,6 +67,8 @@ export ROCKSDB_CLOUD_OBJECT_PATH="dss"
 export TXLOG_ROCKSDB_CLOUD_OBJECT_PATH="txlog"
 
 # --- Download & start Minio ---
+# The build phase does not touch object storage, so it skips all of this.
+if [ "$CI_PHASE" != "build" ]; then
 case "$(uname -m)" in
   x86_64) MINIO_ARCH=amd64 ;;
   aarch64|arm64) MINIO_ARCH=arm64 ;;
@@ -99,6 +108,7 @@ wget -q https://dl.min.io/client/mc/release/linux-${MINIO_ARCH}/mc
 chmod +x mc
 mv mc /usr/local/bin/mc
 mc alias set local http://localhost:9900 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+fi
 
 # --- Workspace setup ---
 # All repos live under GITHUB_WORKSPACE.
@@ -137,22 +147,27 @@ sed -i "s/#\s*StrictHostKeyChecking ask/    StrictHostKeyChecking no/g" /etc/ssh
 
 VENV="${LOG_REPLAY_VENV:-/opt/eloq/log-replay-venv}"
 
-# --- Run build + tests for single (build_type, kv_store_type) ---
-rm -rf ${ELOQKV_BASE_PATH}/eloq_data
+# --- Run build and/or tests for single (build_type, kv_store_type) ---
+if [ "$CI_PHASE" = "build" ]; then
+  rm -rf ${ELOQKV_BASE_PATH}/eloq_data
+  run_build_ent $BUILD_TYPE $KV_STORE_TYPE $txlog_log_state
+fi
 
-run_build_ent $BUILD_TYPE $KV_STORE_TYPE $txlog_log_state
-
-source "$VENV/bin/activate"
-run_eloq_test $BUILD_TYPE $KV_STORE_TYPE
-run_eloqkv_tests $BUILD_TYPE $KV_STORE_TYPE
-run_eloqkv_cluster_tests $BUILD_TYPE $KV_STORE_TYPE
-deactivate
+if [ "$CI_PHASE" = "test" ]; then
+  source "$VENV/bin/activate"
+  run_eloq_test $BUILD_TYPE $KV_STORE_TYPE
+  run_eloqkv_tests $BUILD_TYPE $KV_STORE_TYPE
+  run_eloqkv_cluster_tests $BUILD_TYPE $KV_STORE_TYPE
+  deactivate
+fi
 
 # --- Cleanup Minio ---
-echo "Stopping Minio (pid $MINIO_PID)..."
-kill $MINIO_PID 2>/dev/null || true
-wait $MINIO_PID 2>/dev/null || true
-rm -rf /tmp/minio_data
-rm -f ./minio
+if [ "$CI_PHASE" != "build" ]; then
+  echo "Stopping Minio (pid $MINIO_PID)..."
+  kill $MINIO_PID 2>/dev/null || true
+  wait $MINIO_PID 2>/dev/null || true
+  rm -rf /tmp/minio_data
+  rm -f ./minio
+fi
 
-echo "CI completed successfully for $CI_MODE BUILD_TYPE=$BUILD_TYPE KV_STORE_TYPE=$KV_STORE_TYPE"
+echo "CI $CI_PHASE completed successfully for $CI_MODE BUILD_TYPE=$BUILD_TYPE KV_STORE_TYPE=$KV_STORE_TYPE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           arch: ${{ matrix.arch }}
           cache-scope: ubuntu-dev
 
-      - name: Run CI (${{ matrix.build_type }}, ${{ matrix.kv_store_type }})
+      - name: Build (${{ matrix.build_type }}, ${{ matrix.kv_store_type }})
         env:
           MINIO_ENDPOINT: http://127.0.0.1:9900
           MINIO_ACCESS_KEY: minioadmin
@@ -108,4 +108,22 @@ jobs:
             "$MINIO_ENDPOINT" \
             "$MINIO_ACCESS_KEY" \
             "$MINIO_SECRET_KEY" \
-            "$KV_STORE_TYPE"
+            "$KV_STORE_TYPE" \
+            build
+
+      - name: Test (${{ matrix.build_type }}, ${{ matrix.kv_store_type }})
+        env:
+          MINIO_ENDPOINT: http://127.0.0.1:9900
+          MINIO_ACCESS_KEY: minioadmin
+          MINIO_SECRET_KEY: minioadmin
+          BUILD_TYPE: ${{ matrix.build_type }}
+          KV_STORE_TYPE: ${{ matrix.kv_store_type }}
+          CI_MODE: ${{ github.event_name == 'push' && 'main' || 'pr' }}
+          NODE_MEMORY_LIMIT_MB: 2048
+        run: |
+          bash ./eloqkv/.github/scripts/gh_ci_entry.sh \
+            "$MINIO_ENDPOINT" \
+            "$MINIO_ACCESS_KEY" \
+            "$MINIO_SECRET_KEY" \
+            "$KV_STORE_TYPE" \
+            test


### PR DESCRIPTION
Draft experiment, not for merge. Stacked on #547 for the build/test split.

Changes `eloq_store_pages_per_file_shift` from 1 (8 KB files) to 8 (1 MB) in all 13 CI launch sites, and nothing else.

**Baseline to beat** (from #547, RelWithDebInfo amd64):

| variant | build | test |
|---|---|---|
| ELOQDSS_ELOQSTORE | 22.8 | **86.5** |
| ELOQDSS_ROCKSDB_CLOUD_S3 | 23.6 | 12.9 |
| ROCKSDB | 17.1 | 9.2 |

The gap is entirely in tests. ELOQDSS_ROCKSDB_CLOUD_S3 also goes through DSS and MinIO, so the 6.7x is the storage engine, not object storage per se.

**Hypothesis**: 8 KB files mean 128x the object count of 1 MB files, so cloud mode pays a large number of small HTTP round trips.

**Also watch disk.** The original commit was called "Control the size of eloqstore page size" with no rationale; the name suggests it may have been bounding CI disk usage, in which case this trades wall clock for space.