### PR TITLE
Document source-build runtime library path

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,18 @@ make install
 ```
 
 ### 4. Run EloqKV
+The source build links against the shared libraries installed in Data
+Substrate's third-party workspace. Return to the repository root and add those
+library directories to `LD_LIBRARY_PATH` before starting EloqKV:
+
 ```bash
-cd install
-./bin/eloqkv --config=../../eloqkv.ini
+cd ..
+export LD_LIBRARY_PATH="$PWD/data_substrate/third_party/install/lib:$PWD/data_substrate/third_party/install/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+./build/install/bin/eloqkv --config=eloqkv.ini
 ```
+
+The exported value applies to the current shell. New terminals must export it
+again before running a source-built EloqKV.
 
 ---
 


### PR DESCRIPTION
## Context

Source builds install the EloqKV executable but leave shared dependencies in Data Substrate's third-party workspace. The existing README launch command therefore fails with errors such as `libglog.so.1: cannot open shared object file`.

## Behavior before and after

Before, following the source-build instructions could produce an executable that the dynamic linker could not start. After, the instructions export both third-party `lib` and `lib64` directories through `LD_LIBRARY_PATH` and launch EloqKV from the repository root with the correct config path.

Release and nightly tarball instructions are unchanged; those packaging flows already bundle runtime libraries.

## Implementation

Update the README source-build run section with a copyable `LD_LIBRARY_PATH` command and explain that the export applies to the current shell.

## Design decisions and alternatives

This is a documentation-first fix that matches the current build layout. Bundling runtime libraries during CMake installation is deliberately deferred because it requires separate packaging and transitive-RPATH design work.

## Test plan

- [ ] Unit/TCL tests
- [x] Integration or manual validation
- [x] Formatting/build checks
- [x] Compatibility or performance validation, when relevant

Commands and results:

```text
bash -n <README source-build command block>
# passed

env LD_LIBRARY_PATH="$PWD/data_substrate/third_party/install/lib:$PWD/data_substrate/third_party/install/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd bld/install/bin/eloqkv | rg 'not found'
# produced no output; all runtime libraries resolved

git diff --check
# passed
```

Unit and TCL tests were not run because this change only updates launch documentation.

## Risk assessment

Low. The change affects only source-build documentation. Users must repeat the export in each new shell, as documented. Release and nightly package contents are unaffected.

## Rollback plan

Revert this commit to restore the previous source-build launch instructions.

## Reviewer guide

Review the `Build from Source` run section in `README.md`, especially the paths relative to the repository root.

## Follow-up work

Consider making the CMake install tree self-contained by bundling runtime dependencies and fixing transitive library RPATHs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build-from-source instructions to clarify required shared-library locations.
  * Added guidance to set the required `LD_LIBRARY_PATH` in the current shell before starting EloqKV.
  * Updated the startup command to run EloqKV directly from the build output directory using `--config=eloqkv.ini`.
* **Chores**
  * Updated the `data_substrate` submodule to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->