### PR TITLE
Remove DynamoDB and Bigtable storage backends

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1014,7 +1014,6 @@ function run_build_ent() {
     -DEXT_TX_PROC_ENABLED=ON \
     -DBUILD_WITH_TESTS=ON \
     -DWITH_LOG_SERVICE=ON \
-    -DOPEN_LOG_SERVICE=OFF \
     -DFORK_HM_PROCESS=ON
 
   # Define the output log file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Verify behavior manually with `redis-cli -h 127.0.0.1 -p 6379`.
 Notes:
 - Dependencies: use the `eloqdata/eloq-dev-ci-ubuntu2404` Docker image or run `scripts/install_dependency_ubuntu2404.sh` (ubuntu2404 preferred).
 - Debug builds enable fault injection (`WITH_FAULT_INJECT`); add `--tags -needs:fault_inject` to the TCL command on non-Debug builds.
-- Key CMake options: `WITH_DATA_STORE` (storage backend: `ELOQDSS_ELOQSTORE` default, `ELOQDSS_ROCKSDB` common for local dev, also DynamoDB/BigTable/RocksDB-Cloud variants), `WITH_LOG_STATE`, `WITH_LOG_SERVICE`, `BUILD_ELOQKV_AS_LIBRARY` (build as library for a converged binary instead of the `eloqkv` executable).
+- Key CMake options: `WITH_DATA_STORE` (storage backend: `ELOQDSS_ELOQSTORE` default, `ELOQDSS_ROCKSDB` common for local dev, also embedded RocksDB and RocksDB-Cloud variants), `WITH_LOG_STATE`, `WITH_LOG_SERVICE`, `BUILD_ELOQKV_AS_LIBRARY` (build as library for a converged binary instead of the `eloqkv` executable).
 
 ## Architecture
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ add_compile_definitions(ELOQ_MODULE_ELOQKV)
 option(BUILD_ELOQKV_AS_LIBRARY "Build eloqkv as library instead of executable" OFF)
 
 set(WITH_DATA_STORE "ELOQDSS_ELOQSTORE" CACHE STRING "Which key-value storage to use")
-set_property(CACHE WITH_DATA_STORE PROPERTY STRINGS "DYNAMODB" "BIGTABLE" "ELOQDSS_ROCKSDB_CLOUD_S3" "ELOQDSS_ROCKSDB_CLOUD_GCS" "ELOQDSS_ELOQSTORE" "ELOQDSS_ROCKSDB")
+set_property(CACHE WITH_DATA_STORE PROPERTY STRINGS "ROCKSDB" "ELOQDSS_ROCKSDB_CLOUD_S3" "ELOQDSS_ROCKSDB_CLOUD_GCS" "ELOQDSS_ELOQSTORE" "ELOQDSS_ROCKSDB")
 
 # Keep log-state options visible at the top level so every target shares the
 # same compile definitions as the data_substrate library.
@@ -165,17 +165,9 @@ endif()
 option(VECTOR_INDEX_ENABLED "Enable vector index" OFF)
 message("VECTOR_INDEX_ENABLED: ${VECTOR_INDEX_ENABLED}")
 # Add compile definitions based on options
-if(WITH_DATA_STORE STREQUAL "DYNAMODB")
-    set(KV_STORAGE_VAL 1 CACHE STRING "dynamodb" FORCE)
-    add_compile_definitions(DATA_STORE_TYPE_DYNAMODB)
-    find_package(AWSSDK REQUIRED COMPONENTS dynamodb)
-elseif(WITH_DATA_STORE STREQUAL "ROCKSDB")
+if(WITH_DATA_STORE STREQUAL "ROCKSDB")
     add_compile_definitions(DATA_STORE_TYPE_ROCKSDB)
     include_directories(${PROJECT_SOURCE_DIR}/include)
-elseif(WITH_DATA_STORE STREQUAL "BIGTABLE")
-    set(KV_STORAGE_VAL 2 CACHE STRING "big table" FORCE)
-    add_compile_definitions(DATA_STORE_TYPE_BIGTABLE)
-    find_package(google_cloud_cpp_bigtable REQUIRED)
 elseif(WITH_DATA_STORE STREQUAL "ELOQDSS_ROCKSDB_CLOUD_S3")
     set(KV_STORAGE_VAL 3 CACHE STRING "eloq_ds" FORCE)
     add_compile_definitions(DATA_STORE_TYPE_ELOQDSS_ROCKSDB_CLOUD_S3)
@@ -189,7 +181,7 @@ elseif(WITH_DATA_STORE STREQUAL "ELOQDSS_ELOQSTORE")
     set(KV_STORAGE_VAL 3 CACHE STRING "eloq_ds" FORCE)
     add_compile_definitions(DATA_STORE_TYPE_ELOQDSS_ELOQSTORE)
 else()
-    message(FATAL_ERROR "Unset WITH_DATA_STORE")
+    message(FATAL_ERROR "Unknown WITH_DATA_STORE: ${WITH_DATA_STORE}")
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ EloqKV is a decoupled, distributed database built on [Data Substrate](https://ww
 Each EloqKV instance includes a frontend, compatible with the Redis protocol, deployed together with the core TxService to handle data operations. A logically independent LogService handles Write Ahead Logging (WAL) to ensure persistence, while a Storage Service manages memory state checkpoints and cold data storage.
 
 <!---
-In EloqKV, the TxService is responsible for concurrency control, ensuring that transactional operations are consistent. The Log Service can replicate logs and distributes them across different availability zones (AZs) to provide resilience against AZ-level failures. The storage service supports various persistent storage engines, including local options like RocksDB, cloud storage solutions such as AWS DynamoDB and Object Storage. This persistent storage store cold data for cache misses and provide high availability, even during node failures.
+In EloqKV, the TxService is responsible for concurrency control, ensuring that transactional operations are consistent. The Log Service can replicate logs and distributes them across different availability zones (AZs) to provide resilience against AZ-level failures. The storage service supports RocksDB and EloqStore, backed by local or cloud object storage. This persistent storage store cold data for cache misses and provide high availability, even during node failures.
 -->
 
 ## Benchmark

--- a/src/eloqkv_catalog_factory.cpp
+++ b/src/eloqkv_catalog_factory.cpp
@@ -44,9 +44,7 @@
 #define ELOQDS 1
 #endif
 
-#if defined(DATA_STORE_TYPE_DYNAMODB)
-#include "store_handler/dynamo_handler.h"
-#elif defined(DATA_STORE_TYPE_ROCKSDB)
+#if defined(DATA_STORE_TYPE_ROCKSDB)
 #include "store_handler/rocksdb_handler.h"
 #elif ELOQDS
 #include "data_store_service_client.h"
@@ -61,19 +59,7 @@ RedisTableSchema::RedisTableSchema(const txservice::TableName &redis_table_name,
       schema_image_(catalog_image),
       version_(version)
 {
-#if defined(DATA_STORE_TYPE_DYNAMODB)
-    // TODO(lokax): catalog image format
-    kv_info_ = std::make_unique<EloqDS::DynamoCatalogInfo>();
-    // Catalog image only stores kv_table_name for now.
-    const std::string &kv_table_name = catalog_image;
-    // Use table version as key schema version.
-    uint64_t key_schema_ts = version;
-
-    kv_info_->kv_table_name_ = kv_table_name;
-    key_schema_ = std::make_unique<RedisKeySchema>(key_schema_ts);
-    record_schema_ = std::make_unique<RedisRecordSchema>();
-
-#elif defined(DATA_STORE_TYPE_ROCKSDB)
+#if defined(DATA_STORE_TYPE_ROCKSDB)
     // TODO(lokax): catalog image format
     kv_info_ = std::make_unique<RocksDBCatalogInfo>();
     // Catalog image only stores kv_table_name for now.

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -263,8 +263,6 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
         EloqDS::CassCatalogInfo temp_kv_info(image, "");
         auto kv_info_str = temp_kv_info.Serialize();
         image = EloqDS::SerializeSchemaImage("", kv_info_str, "");
-#elif defined(DATA_STORE_TYPE_DYNAMODB)
-        // TODO(lokax):
 #elif defined(DATA_STORE_TYPE_ROCKSDB)
         // TODO(lokax):
 #endif
@@ -2920,8 +2918,6 @@ bool RedisServiceImpl::ExecuteFlushDBCommand(
     EloqDS::CassCatalogInfo temp_kv_info(new_image, "");
     auto kv_info_str = temp_kv_info.Serialize();
     new_image = EloqDS::SerializeSchemaImage("", kv_info_str, "");
-#elif defined(DATA_STORE_TYPE_DYNAMODB)
-    // TODO(lokax):
 #elif defined(DATA_STORE_TYPE_ROCKSDB)
     // TODO(lokax):
 #endif
@@ -3024,8 +3020,6 @@ bool RedisServiceImpl::ExecuteFlushALLCommand(RedisConnectionContext *ctx,
         EloqDS::CassCatalogInfo temp_kv_info(new_image, "");
         auto kv_info_str = temp_kv_info.Serialize();
         new_image = EloqDS::SerializeSchemaImage("", kv_info_str, "");
-#elif defined(DATA_STORE_TYPE_DYNAMODB)
-        // TODO(lokax):
 #elif defined(DATA_STORE_TYPE_ROCKSDB)
         // TODO(lokax):
 #endif


### PR DESCRIPTION
## Context

DynamoDB and Bigtable are no longer supported storage backends, but EloqKV still advertised both `WITH_DATA_STORE` values and retained backend-specific catalog branches. The enterprise build helper also passed the already-removed `OPEN_LOG_SERVICE` option.

This PR intentionally points `data_substrate` at the companion PR branch commit so EloqKV CI validates the combined change:

- https://github.com/eloqdata/tx_service/pull/536
- `data_substrate` commit: `550fe3db8495b060f2e2a74bbf756be620e4ad6a`

## Behavior before and after

Before, top-level CMake advertised and accepted `DYNAMODB` and `BIGTABLE`; `OPEN_LOG_SERVICE` was passed despite having no consumer.

After, the supported `WITH_DATA_STORE` values are `ROCKSDB`, `ELOQDSS_ROCKSDB`, `ELOQDSS_ROCKSDB_CLOUD_S3`, `ELOQDSS_ROCKSDB_CLOUD_GCS`, and `ELOQDSS_ELOQSTORE`. Removed values fail explicitly with `Unknown WITH_DATA_STORE`.

## Implementation

- Remove DynamoDB and Bigtable from the top-level CMake cache choices and compile-definition branches.
- Remove DynamoDB-specific catalog construction and no-op Redis service branches.
- Remove the stale `OPEN_LOG_SERVICE` argument from `.github/scripts/common.sh`.
- Update build/backend documentation.
- Advance the `data_substrate` pointer from `82cea28` to the companion PR commit `550fe3d`.

## Design decisions and alternatives

The parent PR carries the unmerged companion commit instead of waiting for the submodule PR to land, allowing the full EloqKV CI matrix to exercise both repositories together. The parent pointer must be refreshed to the merged `data_substrate/main` commit before final merge if the companion PR is squash-merged to a different SHA.

## Test plan

- [ ] Unit/TCL tests
- [x] Integration or manual validation
- [x] Formatting/build checks
- [x] Compatibility or performance validation, when relevant

Commands and results:

```text
cmake --build bld-rocksdb --parallel 16                    # passed
cmake --build bld-eloqstore-local --parallel 16            # passed
cmake -S . -B /tmp/eloqkv-invalid-dynamodb... -DWITH_DATA_STORE=DYNAMODB ...  # failed as expected
cmake -S . -B /tmp/eloqkv-invalid-bigtable... -DWITH_DATA_STORE=BIGTABLE ...  # failed as expected
bash -n .github/scripts/common.sh data_substrate/scripts/third_party/build-ubuntu2404.sh  # passed
git diff --check                                           # passed in both repositories
```

`clang-format-18` was unavailable in the workspace. No runtime/TCL tests were run locally; this PR carries the companion branch commit specifically to run the repository CI matrix.

## Risk assessment

This intentionally breaks configurations that still select DynamoDB or Bigtable. Supported RocksDB and EloqStore builds passed locally. The principal integration risk is the temporary submodule pointer to an unmerged commit; reviewers should verify it is replaced with the final reachable `data_substrate/main` commit before merging EloqKV.

## Rollback plan

Revert this PR and the companion `data_substrate` PR.

## Reviewer guide

Review the top-level `CMakeLists.txt`, `src/eloqkv_catalog_factory.cpp`, and the `data_substrate` pointer first. The full backend implementation deletion is in tx_service PR #536.

## Follow-up work

After tx_service PR #536 is merged, update this PR's submodule pointer to the resulting commit on `data_substrate/main` and rerun CI before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Simplified supported data-store options to RocksDB and embedded RocksDB variants, removing DynamoDB/Bigtable paths.
  - Unsupported values now fail fast with an explicit “unknown WITH_DATA_STORE” error.
- **Improvements**
  - Enhanced Cassandra-backed catalog schema handling for pre-created table creation, truncation, and flush operations.
  - Updated build settings to enable transaction processing, tests, and the log service.
- **Documentation**
  - Refined architecture and CMake documentation to reflect the current persistence and available storage options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->