### PR TITLE
Expose EloqStore IO QoS configuration

### DIFF
--- a/eloqkv.ini
+++ b/eloqkv.ini
@@ -130,9 +130,6 @@ node_group_replica_num = 1
 # eloq_store_max_inflight_write: Maximum number of in-flight write operations.
 # eloq_store_max_inflight_write=65536
 
-# eloq_store_max_write_batch_pages: Maximum pages covered by a single write batch.
-# eloq_store_max_write_batch_pages=256
-
 # eloq_store_coroutine_stack_size: Coroutine stack size in bytes for storage workers.
 # eloq_store_coroutine_stack_size=32768
 
@@ -187,6 +184,28 @@ node_group_replica_num = 1
 
 # Maximum number of concurrent standby rsync/ssh jobs managed by EloqStore.
 # eloq_store_standby_max_concurrency=100
+
+# Per-disk IOPS limit. EloqStore divides this budget across the shards using
+# each store path. Set to 0 to disable IOPS limiting.
+# eloq_store_disk_rate_limit_iops=275000
+
+# Per-disk throughput limit in MB/s. Set to 0 to disable byte-rate limiting.
+# eloq_store_disk_rate_limit_mbps=0
+
+# Maximum rate-limit credit that can accumulate while idle, in milliseconds.
+# Smaller values smooth bursts; larger values allow burstier IO.
+# eloq_store_rate_limit_burst_ms=2
+
+# IO size charged as one operation by the IOPS limiter.
+# eloq_store_rate_limit_io_unit=2KB
+
+# Percentage of the rate budget reserved for background reads and writes.
+# EloqStore clamps this value to the range [1, 99].
+# eloq_store_rate_bg_ratio=25
+
+# Maximum number of in-flight device commands per shard. This complements the
+# sustained rate limit with an instantaneous queue-depth bound; 0 disables it.
+# eloq_store_max_inflight_io=0
 
 # size of each data page.
 # eloq_store_data_page_size=4096


### PR DESCRIPTION
## Context

EloqStore added per-device IO rate limiting and an optional in-flight IO window. Once the Data Substrate adapter exposes those settings, EloqKV operators need discoverable sample configuration in `eloqkv.ini`.

Depends on eloqdata/tx_service#537.

## Behavior before and after

Before this change, `eloqkv.ini` documented the obsolete `eloq_store_max_write_batch_pages` setting and did not list the new IO QoS controls.

After this change, the sample config documents:

- `eloq_store_disk_rate_limit_iops`
- `eloq_store_disk_rate_limit_mbps`
- `eloq_store_rate_limit_burst_ms`
- `eloq_store_rate_limit_io_unit`
- `eloq_store_rate_bg_ratio`
- `eloq_store_max_inflight_io`

The obsolete `eloq_store_max_write_batch_pages` entry is removed.

## Implementation

Update only the `[store]` section of `eloqkv.ini`, using defaults and semantics from EloqStore's `KvOptions` and the Data Substrate adapter.

## Design decisions and alternatives

The entries remain commented defaults, consistent with the surrounding EloqStore template. The comments call out that IOPS and bandwidth values are per disk and that EloqStore divides them across shards, preventing operators from treating them as per-shard limits.

## Test plan

- [ ] Unit/TCL tests
- [ ] Integration or manual validation
- [x] Formatting/build checks
- [ ] Compatibility or performance validation

Commands and results:

```text
cmake --build bld --target data_substrate --parallel 4
# Built target data_substrate

cmake --build bld --target eloqkv --parallel 4
# Built target eloqkv

git diff --cached --check
# passed before commit
```

The builds used the corresponding Data Substrate adapter branch from eloqdata/tx_service#537. Runtime and performance tests were not run because this PR changes only the sample INI template. No source formatting was required.

## Risk assessment

Low runtime risk because all new entries are commented. The primary compatibility consideration is removal of documentation for `eloq_store_max_write_batch_pages`, which is already deprecated and ineffective in the corresponding EloqStore version.

This PR must not merge before the Data Substrate adapter is available; otherwise uncommenting the new entries would produce unknown flags/settings.

## Rollback plan

Revert this PR to restore the previous sample configuration.

## Reviewer guide

Review the EloqStore block in `eloqkv.ini`. Compare each name, default, unit, and disable behavior with eloqdata/tx_service#537 and EloqStore `KvOptions`.

## Follow-up work

After the dependent Data Substrate and EloqStore changes land, update EloqKV's data_substrate pointer in a separate change according to the submodule merge policy.