### PR TITLE
feat: enforce Redis maxclients at listener

### DIFF
--- a/docs/02-command-processing.md
+++ b/docs/02-command-processing.md
@@ -47,7 +47,8 @@ service layer only; engine internals are in `data_substrate/docs/` (esp. `02-thr
    listen address, starts the metrics collector thread and namespace GC daemon. In `bootstrap`
    mode it exits the process right here after table creation (`src/redis_service.cpp:704-721`).
 6. brpc `Server::Start()` with `server_options.redis_service = redis_service_impl` (ownership
-   transfers to the server) and optional SSL options; then `RunUntilAskedToQuit()`
+   transfers to the server), the public listener declared Redis-only, `redis_max_connections` set
+   from `maxclients`, and optional force-SSL settings; then `RunUntilAskedToQuit()`
    (`src/redis_server.cpp:502-548`).
 
 ## 2. Request path end-to-end
@@ -99,7 +100,18 @@ key ≤ 32 MB (2 KB for the EloqStore backend) and object ≤ 256 MB
 
 ## 3. Connection state machine
 
-One `RedisConnectionContext` per socket, created by `NewConnectionContext`
+The brpc acceptor enforces `maxclients` only on the Redis-only public listener, immediately after
+the kernel accepts a TCP connection and before it creates a brpc `Socket`. Over-limit plaintext
+connections receive `-ERR max number of clients reached` and are closed; SSL-capable listeners
+close over-limit connections before TLS authentication or handshake work. Other EloqKV brpc/RPC
+servers are not subject to this limit. The acceptor reserves connection slots atomically before
+socket creation, so idle clients count toward the limit and concurrent accepts cannot overshoot it.
+`CONFIG GET maxclients` reports the active limit and `CONFIG SET maxclients <count>` atomically
+changes it for subsequent accepts. Lowering the limit does not disconnect established clients.
+The runtime value is not written back to disk; a restart loads `maxclients` from the `[local]`
+section of `eloqkv.ini` (or its gflag override) again.
+
+One `RedisConnectionContext` per admitted socket, created by `NewConnectionContext`
 (`src/redis_service.cpp:5917`) and owned by brpc's per-socket parsing context. Key fields
 (`include/redis_connection_context.h:61-170`):
 
@@ -304,8 +316,9 @@ the special MOVED/READONLY translations of §6.
 ## 9. Stats, INFO, slow log, metrics
 
 - `RedisStats` (`src/redis_stats.cpp`) exposes brpc bvars when `--enable_redis_stats` (default
-  on): connections received/rejected/closed, blocked clients, read/write/multi-object command
-  counters. Incremented in the connection ctor/dtor and in `ExecuteTxRequest`/
+  on): connections received/closed, blocked clients, and read/write/multi-object command
+  counters. Rejected connections come from the Redis listener's brpc admission counter. The
+  remaining counters are incremented in the connection ctor/dtor and in `ExecuteTxRequest`/
   `ExecuteMultiObjTxRequest` (4486-4496, 4528-4536). `INFO` is a `DirectCommand`
   (`include/redis_command.h:811`) assembled from these counters plus service fields captured at
   Init (OS info, exe path, memory; `src/redis_service.cpp:587-630`).

--- a/eloqkv.ini
+++ b/eloqkv.ini
@@ -24,6 +24,12 @@ ip = 127.0.0.1
 # changed once the server has been launched.
 port = 6379
 
+# Maximum number of simultaneous Redis client connections. This limits only
+# the Redis listener and does not change the process open-file limit. CONFIG
+# SET maxclients updates the running process; after restart this file is read
+# again.
+maxclients = 500000
+
 # EloqKV data directory. By default, the transaction service data, log service data, and local key-value storage data
 # are all stored in the eloq_data_path directory.
 eloq_data_path = eloq_data

--- a/include/redis_command.h
+++ b/include/redis_command.h
@@ -1321,6 +1321,7 @@ struct ConfigCommand : public DirectCommand
     std::vector<std::string_view> keys_;
     std::vector<std::string_view> values_;
     std::vector<std::string> results_;
+    std::string error_message_;
 };
 
 struct TimeCommand : public DirectCommand

--- a/include/redis_service.h
+++ b/include/redis_service.h
@@ -621,6 +621,9 @@ private:
     // after Start(). The pointer is used only by CONFIG SET to update the
     // Redis-only public acceptor's atomic admission limit.
     brpc::Server *brpc_server_{nullptr};
+    // Race-free cache for startup and INFO reads. config_accessing_ serializes
+    // CONFIG mutations; relaxed access here does not synchronize the brpc
+    // acceptor update, which uses its own atomic state.
     std::atomic<uint32_t> max_connection_count_{0};
 
     bool enable_redis_stats_;

--- a/include/redis_service.h
+++ b/include/redis_service.h
@@ -24,8 +24,10 @@
 #include <brpc/redis.h>
 #include <bthread/task_group.h>
 
+#include <atomic>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>  //std::unique_ptr
 #include <string>
@@ -156,6 +158,7 @@ class RedisServiceImpl;
 class NamespaceStorage;
 
 const std::unordered_set<std::string> redis_config_keys = {
+    "maxclients",
     "slowlog-log-slower-than",
     "slowlog-max-len",
 };
@@ -543,6 +546,8 @@ public:
 
     void ResizeSlowLog(uint32_t len);
 
+    // Returns the active Redis listener limit. CONFIG SET may update this
+    // value without changing the startup configuration in DataSubstrate.
     size_t MaxConnectionCount() const;
 
     static bool SendTxRequest(TransactionExecution *txm,
@@ -611,6 +616,12 @@ private:
     // thread that it is acquired.
     std::atomic_bool config_accessing_{false};
     std::unordered_map<std::string, std::string> config_;
+
+    // The Server outlives the service because it owns this RedisServiceImpl
+    // after Start(). The pointer is used only by CONFIG SET to update the
+    // Redis-only public acceptor's atomic admission limit.
+    brpc::Server *brpc_server_{nullptr};
+    std::atomic<uint32_t> max_connection_count_{0};
 
     bool enable_redis_stats_;
     bool skip_kv_;

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -1788,18 +1788,19 @@ void InfoCommand::Execute(RedisServiceImpl *redis_impl,
     max_connection_count_ = redis_impl->MaxConnectionCount();
     active_extern_txms_ = redis_impl->ActiveExternTxCount();
 
+    conn_rejected_count_ =
+        server_acceptor == nullptr
+            ? 0
+            : server_acceptor->RejectedRedisConnectionCount();
+    // The acceptor owns the maxclients slots, so use the same source for
+    // connected_clients. This includes idle sockets that have not sent a
+    // first Redis command yet.
+    connecting_count_ =
+        server_acceptor == nullptr ? 0 : server_acceptor->ConnectionCount();
+
     if (redis_impl->IsEnableRedisStats())
     {
         conn_received_count_ = RedisStats::GetConnReceivedCount();
-        conn_rejected_count_ =
-            server_acceptor == nullptr
-                ? 0
-                : server_acceptor->RejectedRedisConnectionCount();
-        // The acceptor owns the maxclients slots, so use the same source for
-        // connected_clients. This includes idle sockets that have not sent a
-        // first Redis command yet.
-        connecting_count_ =
-            server_acceptor == nullptr ? 0 : server_acceptor->ConnectionCount();
         blocked_clients_count_ = RedisStats::GetBlockedClientsCount();
 
         cmd_read_count_ = RedisStats::GetReadCommandsCount();

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -1791,8 +1791,15 @@ void InfoCommand::Execute(RedisServiceImpl *redis_impl,
     if (redis_impl->IsEnableRedisStats())
     {
         conn_received_count_ = RedisStats::GetConnReceivedCount();
-        conn_rejected_count_ = RedisStats::GetConnRejectedCount();
-        connecting_count_ = RedisStats::GetConnectingCount();
+        conn_rejected_count_ =
+            server_acceptor == nullptr
+                ? 0
+                : server_acceptor->RejectedRedisConnectionCount();
+        // The acceptor owns the maxclients slots, so use the same source for
+        // connected_clients. This includes idle sockets that have not sent a
+        // first Redis command yet.
+        connecting_count_ =
+            server_acceptor == nullptr ? 0 : server_acceptor->ConnectionCount();
         blocked_clients_count_ = RedisStats::GetBlockedClientsCount();
 
         cmd_read_count_ = RedisStats::GetReadCommandsCount();
@@ -2827,6 +2834,11 @@ void ConfigCommand::OutputResult(OutputHandler *reply) const
 {
     if (flag_ == CONFIG_SET)
     {
+        if (!error_message_.empty())
+        {
+            reply->OnError(error_message_);
+            return;
+        }
         reply->OnStatus("OK");
         return;
     }

--- a/src/redis_server.cpp
+++ b/src/redis_server.cpp
@@ -505,10 +505,17 @@ int main(int argc, char *argv[])
     // Notice: redis_service_impl will be deleted in server's destructor.
     server_options.redis_service = redis_service_impl.release();
     server_options.has_builtin_services = false;
+    // This listener is exclusively RESP. Declaring it as such lets brpc
+    // enforce maxclients immediately after accept, before any optional TLS
+    // handshake, without applying the limit to EloqKV's other RPC servers.
+    server_options.enabled_protocols = "redis";
+    server_options.redis_max_connections =
+        redis_service_ptr->MaxConnectionCount();
 
     // Configure TLS if enabled
     if (redis_service_ptr->IsTlsEnabled())
     {
+        server_options.force_ssl = true;
         brpc::ServerSSLOptions *ssl_options =
             server_options.mutable_ssl_options();
 

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -4730,46 +4730,6 @@ void RedisServiceImpl::ExecuteGetConfig(ConfigCommand *cmd)
 
 void RedisServiceImpl::ExecuteSetConfig(ConfigCommand *cmd)
 {
-    std::vector<std::optional<uint32_t>> parsed_maxclients(cmd->keys_.size());
-    for (size_t i = 0; i < cmd->keys_.size(); ++i)
-    {
-        if (cmd->keys_[i] != "maxclients")
-        {
-            continue;
-        }
-
-        uint64_t value = 0;
-        const std::string_view text = cmd->values_[i];
-        if (!text.empty() && text.front() == '-')
-        {
-            cmd->error_message_ =
-                "ERR CONFIG SET failed (possibly related to argument "
-                "'maxclients') - argument must be between 1 and 4294967295 "
-                "inclusive";
-            return;
-        }
-        const auto [end, error] =
-            std::from_chars(text.data(), text.data() + text.size(), value);
-        if (error == std::errc::invalid_argument ||
-            end != text.data() + text.size())
-        {
-            cmd->error_message_ =
-                "ERR CONFIG SET failed (possibly related to argument "
-                "'maxclients') - argument couldn't be parsed into an integer";
-            return;
-        }
-        if (error == std::errc::result_out_of_range || value == 0 ||
-            value > std::numeric_limits<uint32_t>::max())
-        {
-            cmd->error_message_ =
-                "ERR CONFIG SET failed (possibly related to argument "
-                "'maxclients') - argument must be between 1 and 4294967295 "
-                "inclusive";
-            return;
-        }
-        parsed_maxclients[i] = static_cast<uint32_t>(value);
-    }
-
     bool expected = false;
     while (!config_accessing_.compare_exchange_strong(
         expected, true, std::memory_order_acq_rel))
@@ -4781,15 +4741,44 @@ void RedisServiceImpl::ExecuteSetConfig(ConfigCommand *cmd)
     {
         if (cmd->keys_[i] == "maxclients")
         {
-            const uint32_t maxclients = *parsed_maxclients[i];
+            uint64_t value = 0;
+            const std::string_view text = cmd->values_[i];
+            if (!text.empty() && text.front() == '-')
+            {
+                cmd->error_message_ =
+                    "ERR CONFIG SET failed (possibly related to argument "
+                    "'maxclients') - argument must be between 1 and "
+                    "4294967295 inclusive";
+                break;
+            }
+            const auto [end, error] =
+                std::from_chars(text.data(), text.data() + text.size(), value);
+            if (error == std::errc::invalid_argument ||
+                end != text.data() + text.size())
+            {
+                cmd->error_message_ =
+                    "ERR CONFIG SET failed (possibly related to argument "
+                    "'maxclients') - argument couldn't be parsed into an "
+                    "integer";
+                break;
+            }
+            if (error == std::errc::result_out_of_range || value == 0 ||
+                value > std::numeric_limits<uint32_t>::max())
+            {
+                cmd->error_message_ =
+                    "ERR CONFIG SET failed (possibly related to argument "
+                    "'maxclients') - argument must be between 1 and "
+                    "4294967295 inclusive";
+                break;
+            }
+            const uint32_t maxclients = static_cast<uint32_t>(value);
             if (brpc_server_ == nullptr ||
                 brpc_server_->SetRedisMaxConnections(maxclients) != 0)
             {
                 cmd->error_message_ =
                     "ERR CONFIG SET failed (possibly related to argument "
                     "'maxclients') - unable to update the Redis listener";
-                config_accessing_.store(false, std::memory_order_release);
-                return;
+                break;
             }
             max_connection_count_.store(maxclients, std::memory_order_relaxed);
             config_["maxclients"] = std::to_string(maxclients);

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -42,6 +42,7 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -232,6 +233,7 @@ RedisServiceImpl::RedisServiceImpl(const std::string &config_file,
 
 bool RedisServiceImpl::Init(brpc::Server &brpc_server)
 {
+    brpc_server_ = &brpc_server;
     INIReader config_reader(config_file_);
 
     if (!config_file_.empty() && config_reader.ParseError() != 0)
@@ -242,6 +244,10 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
 
     // Engine registration: EloqKv
     auto &ds = DataSubstrate::Instance();
+
+    max_connection_count_.store(ds.GetCoreConfig().maxclients,
+                                std::memory_order_relaxed);
+    config_.try_emplace("maxclients", std::to_string(MaxConnectionCount()));
 
     databases = config_reader.GetInteger("local", "databases", 16);
 
@@ -4724,6 +4730,46 @@ void RedisServiceImpl::ExecuteGetConfig(ConfigCommand *cmd)
 
 void RedisServiceImpl::ExecuteSetConfig(ConfigCommand *cmd)
 {
+    std::vector<std::optional<uint32_t>> parsed_maxclients(cmd->keys_.size());
+    for (size_t i = 0; i < cmd->keys_.size(); ++i)
+    {
+        if (cmd->keys_[i] != "maxclients")
+        {
+            continue;
+        }
+
+        uint64_t value = 0;
+        const std::string_view text = cmd->values_[i];
+        if (!text.empty() && text.front() == '-')
+        {
+            cmd->error_message_ =
+                "ERR CONFIG SET failed (possibly related to argument "
+                "'maxclients') - argument must be between 1 and 4294967295 "
+                "inclusive";
+            return;
+        }
+        const auto [end, error] =
+            std::from_chars(text.data(), text.data() + text.size(), value);
+        if (error == std::errc::invalid_argument ||
+            end != text.data() + text.size())
+        {
+            cmd->error_message_ =
+                "ERR CONFIG SET failed (possibly related to argument "
+                "'maxclients') - argument couldn't be parsed into an integer";
+            return;
+        }
+        if (error == std::errc::result_out_of_range || value == 0 ||
+            value > std::numeric_limits<uint32_t>::max())
+        {
+            cmd->error_message_ =
+                "ERR CONFIG SET failed (possibly related to argument "
+                "'maxclients') - argument must be between 1 and 4294967295 "
+                "inclusive";
+            return;
+        }
+        parsed_maxclients[i] = static_cast<uint32_t>(value);
+    }
+
     bool expected = false;
     while (!config_accessing_.compare_exchange_strong(
         expected, true, std::memory_order_acq_rel))
@@ -4733,13 +4779,29 @@ void RedisServiceImpl::ExecuteSetConfig(ConfigCommand *cmd)
     }
     for (size_t i = 0; i < cmd->keys_.size(); ++i)
     {
-        config_[std::string(cmd->keys_[i])] = std::string(cmd->values_[i]);
-        if (cmd->keys_[i] == "slowlog-log-slower-than")
+        if (cmd->keys_[i] == "maxclients")
         {
+            const uint32_t maxclients = *parsed_maxclients[i];
+            if (brpc_server_ == nullptr ||
+                brpc_server_->SetRedisMaxConnections(maxclients) != 0)
+            {
+                cmd->error_message_ =
+                    "ERR CONFIG SET failed (possibly related to argument "
+                    "'maxclients') - unable to update the Redis listener";
+                config_accessing_.store(false, std::memory_order_release);
+                return;
+            }
+            max_connection_count_.store(maxclients, std::memory_order_relaxed);
+            config_["maxclients"] = std::to_string(maxclients);
+        }
+        else if (cmd->keys_[i] == "slowlog-log-slower-than")
+        {
+            config_[std::string(cmd->keys_[i])] = std::string(cmd->values_[i]);
             slow_log_threshold_ = std::stoul(std::string(cmd->values_[i]));
         }
         else if (cmd->keys_[i] == "slowlog-max-len")
         {
+            config_[std::string(cmd->keys_[i])] = std::string(cmd->values_[i]);
             ResizeSlowLog(std::stoul(std::string(cmd->values_[i])));
         }
     }
@@ -6514,8 +6576,7 @@ metrics::Meter *RedisServiceImpl::GetMeter(std::size_t core_id) const
 
 size_t RedisServiceImpl::MaxConnectionCount() const
 {
-    auto &ds = DataSubstrate::Instance();
-    return ds.GetCoreConfig().maxclients;
+    return max_connection_count_.load(std::memory_order_relaxed);
 }
 
 }  // namespace EloqKV

--- a/tests/unit/eloq/maxclients.tcl
+++ b/tests/unit/eloq/maxclients.tcl
@@ -9,9 +9,14 @@ start_server {tags {"maxclients network"}} {
         # limit is below the current connection count.
         assert_equal {PONG} [r ping]
 
+        if {$::tls} {
+            set expected_rejection {*I/O error*}
+        } else {
+            set expected_rejection {*ERR max*reached*}
+        }
         set rejected [catch {redis_deferring_client} rejection]
         assert_equal {1} $rejected
-        assert_match {*ERR max*reached*} $rejection
+        assert_match $expected_rejection $rejection
 
         assert_error {*argument must be between 1 and 4294967295 inclusive*} {
             r config set maxclients 0

--- a/tests/unit/eloq/maxclients.tcl
+++ b/tests/unit/eloq/maxclients.tcl
@@ -1,0 +1,26 @@
+start_server {tags {"maxclients network"}} {
+    test {CONFIG GET and SET expose the live maxclients limit} {
+        set original [lindex [r config get maxclients] 1]
+
+        assert_equal {OK} [r config set maxclients 1]
+        assert_equal {1} [lindex [r config get maxclients] 1]
+
+        # The connection issuing CONFIG SET remains established when the new
+        # limit is below the current connection count.
+        assert_equal {PONG} [r ping]
+
+        set rejected [catch {redis_deferring_client} rejection]
+        assert_equal {1} $rejected
+        assert_match {*ERR max*reached*} $rejection
+
+        assert_error {*argument must be between 1 and 4294967295 inclusive*} {
+            r config set maxclients 0
+        }
+        assert_error {*argument couldn't be parsed into an integer*} {
+            r config set maxclients invalid
+        }
+        assert_equal {1} [lindex [r config get maxclients] 1]
+
+        r config set maxclients $original
+    }
+}


### PR DESCRIPTION
## Context

EloqKV previously treated `maxclients` as a process-wide `RLIMIT_NOFILE` setting. That both reserved file descriptors poorly and risked starving storage files and internal RPC connections. It also could not reject an over-limit TLS client until after expensive TLS work.

This PR moves admission control to brpc's Redis-only public listener. It depends on [eloqdata/tx_service#560](https://github.com/eloqdata/tx_service/pull/560), which consumes the merged Redis listener work in [eloqdata/brpc#29](https://github.com/eloqdata/brpc/pull/29) and the merged partial-write rejection fix in [eloqdata/brpc#30](https://github.com/eloqdata/brpc/pull/30).

## Behavior before and after

Before, `maxclients` changed the API process's file-descriptor limit and was not available through `CONFIG GET/SET`. Admission was not scoped to Redis, and a TLS connection could consume handshake/authentication CPU before being rejected.

After, `maxclients` limits simultaneous connections only on EloqKV's Redis listener. Plaintext clients receive `-ERR max number of clients reached`; TLS clients are closed immediately after `accept()` and before TLS authentication or handshake. EloqKV's internal brpc servers, host-manager connection, metrics traffic, and ordinary file opens are outside this limit.

`CONFIG GET maxclients` returns the live value and `CONFIG SET maxclients <1..4294967295>` updates the acceptor atomically for subsequent admissions. Lowering the value does not disconnect established clients. Runtime changes are not persisted; restart reads `[local].maxclients` from `eloqkv.ini` again.

## Implementation

- Declare the public brpc server Redis-only and pass the configured limit through `ServerOptions::redis_max_connections`.
- Set `force_ssl` for TLS listeners so an over-limit socket is rejected before any TLS processing.
- Keep a live atomic maxclients value in `RedisServiceImpl` and update brpc through `Server::SetRedisMaxConnections()` from `CONFIG SET`.
- Validate dynamic values before changing the listener or the CONFIG-visible value.
- Source `connected_clients` and `rejected_connections` INFO fields from the acceptor that owns admission slots, including idle sockets that have not sent a command.
- Add the default configuration, operational documentation, and a TCL regression test.
- Advance `data_substrate` to commit `1d12310a50e36d6f372103cd223cd9c30c32a5d4` from its PR branch.

## Design decisions and alternatives

The protocol-specific acceptor is the first layer that can reject Redis clients without affecting other RPC traffic. Doing this immediately after kernel `accept()` also avoids allocating a brpc socket or performing TLS work for rejected clients. Atomic slot reservation prevents concurrent accepts from overshooting the configured limit.

Changing the live limit affects only future admissions. Disconnecting existing clients when a limit is lowered would be disruptive and would differ from Redis/Valkey operational expectations.

## Test plan

- [x] Unit/TCL tests
- [x] Integration or manual validation
- [x] Formatting/build checks
- [x] Compatibility or performance validation, when relevant

Commands and results:

```text
cmake --build /tmp/eloqdata-brpc-partial-build --target install --parallel 4
  passed; installed the merged eloqdata/brpc#30 tree to /opt/eloq/third_party

cmake --build /home/ubuntu/eloqkv/bld-rocksdb-cloud \
  --target eloqkv --parallel 4
  passed: [100%] Built target eloqkv

env AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
  LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64 \
  ./eloqkv \
  --config=/tmp/eloqkv-maxclients-runtime-20260828-b/eloqkv.ini \
  --logtostderr
  passed: RocksDB Cloud single-node server started on 127.0.0.1:17779

tclsh tests/test_helper.tcl --host 127.0.0.1 --port 17779 \
  --tags -needs:repl --tags -needs:config-maxmemory --tags -needs:debug \
  --tags -needs:redis_config --tags -needs:redis_expire \
  --tags -needs:slow_test --tags -needs:support_cmd_later \
  --tags -needs:cluster_mode --tags -needs:fault_inject \
  --single /unit/eloq/maxclients
  passed: 1/1, all tests passed without errors

git diff --check origin/main...HEAD
  passed

clang-format-18 --dry-run --Werror <changed C++ files>
  not clean as a whole: include/redis_command.h has three pre-existing style
  violations around lines 1374, 7810, and 7815, outside this PR's changed line
```

The full EloqKV TCL suite and TLS-specific load test were not run in this workspace. The listener-level plaintext/TLS rejection paths are covered by the merged brpc dependency's tests and CI.

## Risk assessment

The main regression surface is connection accounting during concurrent accept/close and the lifetime of the server pointer used by `CONFIG SET`. brpc owns the slot counter and releases reservations on every socket-creation failure and close path; the server outlives the service it owns. Transaction, WAL, storage, durability, and recovery paths are unchanged.

Deployments that relied on EloqKV to change `RLIMIT_NOFILE` must configure OS file-descriptor limits independently. A configured `maxclients` value can still exceed the available OS file descriptors, in which case ordinary OS resource exhaustion applies.

## Rollback plan

Revert this PR and restore the prior `data_substrate` gitlink. Operators can independently restore the previous OS limit configuration if required.

## Reviewer guide

Start in `src/redis_server.cpp` to verify the listener is Redis-only and the limit is applied before TLS. Review `RedisServiceImpl::ExecuteSetConfig()` for validation and atomic runtime updates, then `InfoCommand::Execute()` for acceptor-owned counters. Finally review `tests/unit/eloq/maxclients.tcl`, the sample config/docs, and confirm the `data_substrate` gitlink matches eloqdata/tx_service#560.

## Follow-up work

After eloqdata/tx_service#560 lands, advance this PR's `data_substrate` gitlink from the PR head to the merge commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable `maxclients` limit for simultaneous Redis connections.
  * Supports runtime updates through `CONFIG SET` and viewing the limit with `CONFIG GET`.
  * Connection statistics now include connected and rejected Redis clients.

* **Bug Fixes**
  * Added validation and clear errors for invalid client-limit values.
  * Enforced connection limits before optional SSL negotiation.

* **Documentation**
  * Documented client-limit configuration, enforcement, and connection statistics.

* **Tests**
  * Added coverage for runtime configuration, rejected connections, and invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->