### PR TITLE
feat: add administrative Redis listener

### DIFF
--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -474,16 +474,18 @@ function bootstrap_eloqkv() {
 #                <data_store> [extra...]
 function run_scenario() {
   local store_type=$1 log_name=$2 build_type=$3 evicted=$4 wal=$5 data_store=$6
+  local admin_port=6380
   shift 6
 
-  launch_eloqkv "${store_type}" "${log_name}" 6379 "${wal}" "${data_store}" "$@"
+  launch_eloqkv "${store_type}" "${log_name}" 6379 "${wal}" "${data_store}" \
+    --admin_port="${admin_port}" "$@"
   wait_until_ready
   echo "Redis server is ready!"
 
   # See run_cluster_scenario: tear down from a trap so a failing suite still
   # releases the port.
   trap stop_single_node RETURN
-  run_tcl_tests all "${build_type}" false "${evicted}"
+  run_tcl_tests all "${build_type}" false "${evicted}" "${admin_port}"
 }
 
 # Stop the node started by the enclosing run_scenario.
@@ -579,6 +581,7 @@ function run_tcl_tests() {
     fault_inject=""
   fi
   local evicted=${4:-false}
+  local admin_port=${5:-0}
   local no_evicted="--tags -needs:no_evicted"
   if [[ $evicted = "false" ]]; then
     no_evicted=""
@@ -593,6 +596,7 @@ function run_tcl_tests() {
     tclsh tests/test_helper.tcl \
     --host 127.0.0.1 \
     --port 6379 \
+    --admin-port ${admin_port} \
     --tags -needs:repl \
     --tags -needs:config-maxmemory \
     --tags -needs:debug \

--- a/docs/02-command-processing.md
+++ b/docs/02-command-processing.md
@@ -48,8 +48,12 @@ service layer only; engine internals are in `data_substrate/docs/` (esp. `02-thr
    mode it exits the process right here after table creation (`src/redis_service.cpp:704-721`).
 6. brpc `Server::Start()` with `server_options.redis_service = redis_service_impl` (ownership
    transfers to the server), the public listener declared Redis-only, `redis_max_connections` set
-   from `maxclients`, and optional force-SSL settings; then `RunUntilAskedToQuit()`
-   (`src/redis_server.cpp:502-548`).
+   from `maxclients`, and optional force-SSL settings. When `admin_port` is nonzero, a second
+   Redis-only `brpc::Server` starts on the same bind address with an independent
+   `admin_maxclients` limit. Its non-owning service proxy forwards connection-context creation and
+   every command to the primary `RedisServiceImpl`, so command, authentication, namespace, and TLS
+   behavior remain shared. The primary server then waits in `RunUntilAskedToQuit()`
+   (`src/redis_server.cpp`).
 
 ## 2. Request path end-to-end
 
@@ -110,6 +114,16 @@ socket creation, so idle clients count toward the limit and concurrent accepts c
 changes it for subsequent accepts. Lowering the limit does not disconnect established clients.
 The runtime value is not written back to disk; a restart loads `maxclients` from the `[local]`
 section of `eloqkv.ini` (or its gflag override) again.
+
+An optional administrative listener (`admin_port`, disabled by default) has its own Acceptor and
+fixed `admin_maxclients` admission limit. Reaching the primary `maxclients` therefore does not
+consume administrative connection slots. `CONFIG SET maxclients` deliberately continues to
+update only the primary listener, preserving the independent escape path. Both listeners share
+the same process file-descriptor limit and bthread/engine resources: deployments must leave FD
+headroom above `maxclients + admin_maxclients`, and the second listener does not guarantee access
+after process-wide FD, memory, CPU, or scheduler exhaustion. The administrative port inherits the
+primary bind address, authentication, and force-TLS configuration and exposes the same command
+dispatcher; protect it with host/network access controls.
 
 One `RedisConnectionContext` per admitted socket, created by `NewConnectionContext`
 (`src/redis_service.cpp:5917`) and owned by brpc's per-socket parsing context. Key fields

--- a/eloqkv.ini
+++ b/eloqkv.ini
@@ -30,6 +30,17 @@ port = 6379
 # again.
 maxclients = 500000
 
+# Optional second Redis listener for administrative access when the primary
+# listener has reached maxclients. It accepts the same commands and inherits
+# the primary listener's bind address, authentication, and TLS configuration.
+# Keep this port protected by the host firewall. A value of 0 disables it.
+admin_port = 0
+
+# Independent connection limit for the administrative listener. Ensure the
+# process open-file limit leaves room for these connections and internal file
+# descriptors after the primary listener reaches maxclients.
+admin_maxclients = 16
+
 # EloqKV data directory. By default, the transaction service data, log service data, and local key-value storage data
 # are all stored in the eloq_data_path directory.
 eloq_data_path = eloq_data

--- a/src/redis_server.cpp
+++ b/src/redis_server.cpp
@@ -25,6 +25,8 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 
+#include <cstdint>
+#include <limits>
 #include <sstream>
 #include <string>
 
@@ -43,6 +45,12 @@ constexpr char VERSION[] = "1.3.2";
 // EloqKV flags - these are converted to tx flags
 DEFINE_string(ip, "127.0.0.1", "Redis IP");
 DEFINE_int32(port, 6379, "Redis Port");
+DEFINE_int32(admin_port,
+             0,
+             "Administrative Redis port; 0 disables the admin listener");
+DEFINE_uint32(admin_maxclients,
+              16,
+              "Maximum connections accepted by the admin Redis listener");
 DEFINE_string(ip_port_list, "", "redis server cluster ip port list");
 DEFINE_string(standby_ip_port_list,
               "",
@@ -62,6 +70,80 @@ DEFINE_string(voter_ip_port_list,
 // Global variable defined in redis_service.cpp
 extern brpc::Acceptor *EloqKV::server_acceptor;
 extern std::string EloqKV::redis_ip_port;
+
+namespace
+{
+/**
+ * A non-owning Redis service view for the administrative listener.
+ *
+ * brpc::Server owns and deletes ServerOptions::redis_service, so the primary
+ * RedisServiceImpl cannot be installed in two Server instances directly. The
+ * primary Server owns the implementation; the administrative Server owns this
+ * proxy and is always stopped and destroyed first.
+ */
+class RedisServiceProxy final : public brpc::RedisService
+{
+public:
+    explicit RedisServiceProxy(EloqKV::RedisServiceImpl *service)
+        : service_(service)
+    {
+    }
+
+    std::unique_ptr<brpc::ConnectionContext> NewConnectionContext(
+        brpc::Socket *socket) const override
+    {
+        return service_->NewConnectionContext(socket);
+    }
+
+    brpc::RedisCommandHandlerResult DispatchCommand(
+        brpc::ConnectionContext *ctx,
+        const std::vector<butil::StringPiece> &args,
+        brpc::RedisReply *output,
+        bool flush_batched) const override
+    {
+        return service_->DispatchCommand(ctx, args, output, flush_batched);
+    }
+
+private:
+    EloqKV::RedisServiceImpl *service_;
+};
+
+void ConfigureRedisListener(brpc::ServerOptions *options,
+                            EloqKV::RedisServiceImpl *redis_service,
+                            size_t max_connections,
+                            const char *listener_name)
+{
+    std::string n_bthreads;
+    GFLAGS_NAMESPACE::GetCommandLineOption("bthread_concurrency", &n_bthreads);
+    options->num_threads = std::stoi(n_bthreads);
+    options->has_builtin_services = false;
+    options->enabled_protocols = "redis";
+    options->redis_max_connections = max_connections;
+
+    if (!redis_service->IsTlsEnabled())
+    {
+        return;
+    }
+
+    options->force_ssl = true;
+    brpc::ServerSSLOptions *ssl_options = options->mutable_ssl_options();
+    ssl_options->default_cert.certificate = redis_service->GetTlsCertFile();
+    ssl_options->default_cert.private_key = redis_service->GetTlsKeyFile();
+
+    LOG(INFO) << "TLS enabled for " << listener_name
+              << " Redis listener. Certificate: "
+              << redis_service->GetTlsCertFile()
+              << ", Key: " << redis_service->GetTlsKeyFile();
+}
+
+std::string RedisListenAddress(uint32_t port)
+{
+    const auto &network_config = DataSubstrate::Instance().GetNetworkConfig();
+    const std::string ip =
+        network_config.bind_all ? "0.0.0.0" : network_config.local_ip;
+    return ip + ":" + std::to_string(port);
+}
+}  // namespace
 
 void PrintHelloText()
 {
@@ -450,6 +532,33 @@ int main(int argc, char *argv[])
     // Convert eloqkv flags to tx flags
     ConvertEloqkvFlagsToTxFlags(&config_reader);
 
+    const int64_t configured_admin_port =
+        IsEloqkvFlagSet("admin_port")
+            ? FLAGS_admin_port
+            : config_reader.GetInteger("local", "admin_port", FLAGS_admin_port);
+    const int64_t configured_admin_maxclients =
+        IsEloqkvFlagSet("admin_maxclients")
+            ? FLAGS_admin_maxclients
+            : config_reader.GetInteger(
+                  "local", "admin_maxclients", FLAGS_admin_maxclients);
+    if (configured_admin_port < 0 ||
+        configured_admin_port > std::numeric_limits<uint16_t>::max())
+    {
+        LOG(ERROR) << "admin_port must be between 0 and "
+                   << std::numeric_limits<uint16_t>::max();
+        return -1;
+    }
+    if (configured_admin_maxclients <= 0 ||
+        configured_admin_maxclients > std::numeric_limits<uint32_t>::max())
+    {
+        LOG(ERROR) << "admin_maxclients must be between 1 and "
+                   << std::numeric_limits<uint32_t>::max();
+        return -1;
+    }
+    const uint32_t admin_port = static_cast<uint32_t>(configured_admin_port);
+    const uint32_t admin_maxclients =
+        static_cast<uint32_t>(configured_admin_maxclients);
+
     // Step 1: Initialize DataSubstrate
     if (!DataSubstrate::Instance().Init(config_file))
     {
@@ -461,6 +570,9 @@ int main(int argc, char *argv[])
     LOG(INFO) << "Starting EloqKV Server ...";
     DataSubstrate::Instance().EnableEngine(txservice::TableEngine::EloqKv);
     brpc::Server server;
+    // Declared after the primary Server so that its non-owning Redis service
+    // proxy is destroyed before the primary Server deletes RedisServiceImpl.
+    brpc::Server admin_server;
     brpc::ServerOptions server_options;
     auto redis_service_impl =
         std::make_unique<EloqKV::RedisServiceImpl>(config_file, VERSION);
@@ -499,37 +611,26 @@ int main(int argc, char *argv[])
 #endif
         return -1;
     }
-    std::string n_bthreads;
-    GFLAGS_NAMESPACE::GetCommandLineOption("bthread_concurrency", &n_bthreads);
-    server_options.num_threads = std::stoi(n_bthreads);
+    if (admin_port != 0 && admin_port == redis_service_ptr->GetRedisPort())
+    {
+        LOG(ERROR) << "admin_port must differ from the primary Redis port";
+        redis_service_ptr->Stop();
+        DataSubstrate::Instance().Shutdown();
+#if BRPC_WITH_GLOG
+        google::ShutdownGoogleLogging();
+#endif
+        return -1;
+    }
+
     // Notice: redis_service_impl will be deleted in server's destructor.
     server_options.redis_service = redis_service_impl.release();
-    server_options.has_builtin_services = false;
     // This listener is exclusively RESP. Declaring it as such lets brpc
     // enforce maxclients immediately after accept, before any optional TLS
     // handshake, without applying the limit to EloqKV's other RPC servers.
-    server_options.enabled_protocols = "redis";
-    server_options.redis_max_connections =
-        redis_service_ptr->MaxConnectionCount();
-
-    // Configure TLS if enabled
-    if (redis_service_ptr->IsTlsEnabled())
-    {
-        server_options.force_ssl = true;
-        brpc::ServerSSLOptions *ssl_options =
-            server_options.mutable_ssl_options();
-
-        // Set server certificate and key (required when TLS is enabled)
-        // Validation in Init() ensures both files are provided
-        ssl_options->default_cert.certificate =
-            redis_service_ptr->GetTlsCertFile();
-        ssl_options->default_cert.private_key =
-            redis_service_ptr->GetTlsKeyFile();
-
-        LOG(INFO) << "TLS enabled for brpc server. Certificate: "
-                  << redis_service_ptr->GetTlsCertFile()
-                  << ", Key: " << redis_service_ptr->GetTlsKeyFile();
-    }
+    ConfigureRedisListener(&server_options,
+                           redis_service_ptr,
+                           redis_service_ptr->MaxConnectionCount(),
+                           "primary");
 
     if (server.Start(redis_ip_port.c_str(), &server_options) != 0)
     {
@@ -541,6 +642,37 @@ int main(int argc, char *argv[])
 #endif
         return -1;
     }
+    EloqKV::server_acceptor = server.GetAcceptor();
+
+    std::string admin_ip_port;
+    if (admin_port != 0)
+    {
+        admin_ip_port = RedisListenAddress(admin_port);
+        brpc::ServerOptions admin_server_options;
+        // The proxy exposes exactly the same service behavior while keeping
+        // ownership and connection admission independent between listeners.
+        admin_server_options.redis_service =
+            new RedisServiceProxy(redis_service_ptr);
+        ConfigureRedisListener(&admin_server_options,
+                               redis_service_ptr,
+                               admin_maxclients,
+                               "administrative");
+        if (admin_server.Start(admin_ip_port.c_str(), &admin_server_options) !=
+            0)
+        {
+            LOG(ERROR) << "Failed to start the administrative Redis listener "
+                       << "on " << admin_ip_port;
+            server.Stop(0);
+            server.Join();
+            EloqKV::server_acceptor = nullptr;
+            redis_service_ptr->Stop();
+            DataSubstrate::Instance().Shutdown();
+#if BRPC_WITH_GLOG
+            google::ShutdownGoogleLogging();
+#endif
+            return -1;
+        }
+    }
 
     if (!FLAGS_alsologtostderr)
     {
@@ -549,10 +681,27 @@ int main(int argc, char *argv[])
     }
     LOG(INFO) << "==== EloqKV Server Started, listening on " << redis_ip_port
               << "====";
-
-    EloqKV::server_acceptor = server.GetAcceptor();
+    if (admin_port != 0)
+    {
+        if (!FLAGS_alsologtostderr)
+        {
+            std::cout << "Administrative Redis listener started on "
+                      << admin_ip_port << std::endl;
+        }
+        LOG(INFO) << "==== Administrative Redis listener started on "
+                  << admin_ip_port << ", maxclients=" << admin_maxclients
+                  << " ====";
+    }
 
     server.RunUntilAskedToQuit();
+
+    // Stop the proxy listener before stopping the shared RedisServiceImpl.
+    if (admin_server.IsRunning())
+    {
+        admin_server.Stop(0);
+        admin_server.Join();
+    }
+    EloqKV::server_acceptor = nullptr;
 
     if (!FLAGS_alsologtostderr)
     {

--- a/tests/test_helper.tcl
+++ b/tests/test_helper.tcl
@@ -124,6 +124,7 @@ set ::next_test 0
 
 set ::host 127.0.0.1
 set ::port 6379; # port for external server
+set ::admin_port 0; # optional administrative port for external server tests
 set ::baseport 21111; # initial port for spawned redis servers
 set ::portcount 8000; # we don't wanna use more than 10000 to avoid collision with cluster bus ports
 set ::traceleaks 0
@@ -645,6 +646,7 @@ proc print_help_screen {} {
         "--tls-module       Run tests in TLS mode with Redis module."
         "--host <addr>      Run tests against an external host."
         "--port <port>      TCP port to use against external host."
+        "--admin-port <port> Administrative port of the external host, if enabled."
         "--baseport <port>  Initial port number for spawned redis servers."
         "--portcount <num>  Port range for spawned redis servers."
         "--singledb         Use a single database, avoid SELECT."
@@ -711,6 +713,9 @@ for {set j 0} {$j < [llength $argv]} {incr j} {
         incr j
     } elseif {$opt eq {--port}} {
         set ::port $arg
+        incr j
+    } elseif {$opt eq {--admin-port}} {
+        set ::admin_port $arg
         incr j
     } elseif {$opt eq {--baseport}} {
         set ::baseport $arg

--- a/tests/unit/eloq/maxclients.tcl
+++ b/tests/unit/eloq/maxclients.tcl
@@ -28,4 +28,26 @@ start_server {tags {"maxclients network"}} {
 
         r config set maxclients $original
     }
+
+    if {$::admin_port != 0} {
+        test {Admin listener remains available when primary maxclients is reached} {
+            set original [lindex [r config get maxclients] 1]
+            assert_equal {OK} [r config set maxclients 1]
+
+            if {$::tls} {
+                set expected_rejection {*I/O error*}
+            } else {
+                set expected_rejection {*ERR max*reached*}
+            }
+            set rejected [catch {redis_deferring_client} rejection]
+            assert_equal {1} $rejected
+            assert_match $expected_rejection $rejection
+
+            set admin [redis $::host $::admin_port 0 $::tls]
+            assert_equal {PONG} [$admin ping]
+            $admin close
+
+            r config set maxclients $original
+        }
+    }
 }


### PR DESCRIPTION
## Context

A leaked or exhausted set of client connections can consume the primary Redis listener's `maxclients` budget and prevent operators from connecting to diagnose or mitigate the problem. EloqKV needs an optional administrative entry point whose connection admission is independent from the public listener while preserving normal Redis behavior.

## Behavior before and after

Before this change, EloqKV exposes one Redis listener. Once that listener reaches `maxclients`, every new Redis connection is rejected.

After this change, `admin_port` can enable a second Redis listener with its own `admin_maxclients` budget. Reaching the primary listener's limit does not consume administrative slots. The administrative listener exposes the same commands and shared data, and inherits the primary bind address, authentication/namespace behavior, and TLS certificate/key configuration. Both options are backward compatible: `admin_port` defaults to `0` (disabled), and `admin_maxclients` defaults to `16`.

## Implementation

- Start a second Redis-only `brpc::Server` when `admin_port` is nonzero.
- Give each server its own Acceptor and Redis connection limit.
- Install a non-owning `RedisServiceProxy` on the administrative server that forwards connection-context creation and command dispatch to the primary `RedisServiceImpl`.
- Share listener setup for RESP-only protocol and force-TLS configuration.
- Validate the administrative port/range and reject a collision with the primary Redis port.
- Stop and destroy the proxy listener before stopping the shared service implementation.
- Extend the Tcl harness and single-node CI launch to verify administrative access after primary `maxclients` exhaustion.
- Document configuration, lifecycle, shared-resource limitations, and network-access expectations.

## Design decisions and alternatives

`brpc::Server` owns `ServerOptions::redis_service`, so the same service object cannot safely be installed in two servers. The proxy preserves one command/authentication implementation without double ownership, while separate `brpc::Server` instances provide independent Acceptors and admission counters.

`CONFIG SET maxclients` continues to update only the primary listener. This preserves the administrative escape path. The administrative listener intentionally uses the same credentials and TLS files as the primary listener; access isolation is expected to come from firewall or management-network policy.

No brpc or `data_substrate` changes are required.

## Test plan

- [x] Unit/TCL tests
- [x] Integration or manual validation
- [x] Formatting/build checks
- [x] Compatibility validation; no performance benchmark was run

Commands and results:

```text
cmake --build bld-eloqstore-local --parallel 16 --target eloqkv
# Passed; eloqkv built successfully.

tclsh tests/test_helper.tcl --host 127.0.0.1 --port 16621 --admin-port 16623 --tags -needs:repl --tags -needs:config-maxmemory --tags -needs:debug --tags -needs:redis_config --tags -needs:redis_expire --tags -needs:slow_test --tags -needs:support_cmd_later --tags -needs:cluster_mode --single /unit/eloq/maxclients
# Passed: 2 tests, including rejection on the exhausted primary listener and PONG on the administrative listener.

bash -n .github/scripts/common.sh
tclsh tests/test_helper.tcl --help >/dev/null
clang-format-18 --dry-run --Werror src/redis_server.cpp
git diff --check origin/main...HEAD
# All passed.
```

Manual validation also covered shared SET/GET data, `CLIENT LIST`, raising primary `maxclients` through the administrative listener, independent exhaustion of `admin_maxclients`, shared `requirepass` authentication, invalid option ranges, and graceful shutdown of both listeners.

TLS runtime validation was not run because the local checkout does not contain the expected `tests/tls/server.crt` fixture. Both listeners use the same listener configuration helper and certificate/key values.

A build using the pre-existing `bld-rocksdb` directory was attempted but is not counted as passing: that stale build configuration fails in `data_substrate/tx_service.h` because `eloq::ModuleType` is unavailable, outside this diff.

## Risk assessment

The second listener adds socket/lifecycle surface in `redis_server.cpp`. Startup failure of the administrative listener shuts down the already-started primary listener and returns an error, avoiding a silently missing operational endpoint.

The two listeners still share the process file-descriptor limit, CPU, memory, bthread scheduler, and transaction engine. Administrative availability is therefore protected from primary Redis admission exhaustion, not from process-wide resource exhaustion. Because credentials are shared, deployments must restrict `admin_port` at the network layer.

## Rollback plan

Set `admin_port = 0` to disable the listener without changing data or restart compatibility. Revert this PR to remove the configuration and listener code entirely; no migration is required.

## Reviewer guide

1. Review `RedisServiceProxy`, `ConfigureRedisListener`, and server lifetime ordering in `src/redis_server.cpp`.
2. Verify that `server_acceptor` remains associated with the primary listener so `CLIENT` and `CONFIG SET maxclients` retain their intended behavior.
3. Review `tests/unit/eloq/maxclients.tcl` and `.github/scripts/common.sh` for the CI coverage path.
4. Review `eloqkv.ini` and `docs/02-command-processing.md` for operational constraints.

## Follow-up work

Independent administrative credentials, bind address, and TLS certificates are deliberately not included; the requested behavior is to connect to both ports with the same client settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional administrative Redis listener on a separate port.
  * Administrative access remains available when the primary listener reaches its connection limit.
  * Added independent connection-limit configuration for the administrative listener.
  * Added validation to prevent invalid ports and conflicts with the primary listener.

* **Documentation**
  * Documented administrative listener configuration, shared behavior, and access-control considerations.

* **Tests**
  * Added coverage verifying administrative access remains available when the primary connection limit is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->