### PR TITLE
fix: support optional and required TLS listener modes

### DIFF
--- a/docs/01-architecture-overview.md
+++ b/docs/01-architecture-overview.md
@@ -55,7 +55,7 @@ Defined in `src/redis_server.cpp` / `src/redis_service.cpp`; engine flags are li
 | `cluster_mode` | — | strict Redis Cluster compatibility behavior |
 | `txn_isolation_level` / `protocol` / `isolation_level` | — | engine isolation/cc-protocol selection for txs ([02](02-command-processing.md)) |
 | `retry_on_occ_error` | — | auto-retry policy for OCC conflicts |
-| `enable_tls` / `tls_cert_file` / `tls_key_file` | off | TLS on the RESP port |
+| `enable_tls` / `tls_cert_file` / `tls_key_file` | off | optional TLS alongside plaintext on the RESP port |
 | `slow_log_threshold` / `slow_log_max_length` | — | SLOWLOG |
 | `enable_redis_stats`, `enable_cmd_sort` | — | INFO/stats behavior |
 | `cc_notify` | — | notify-based (vs polling) wakeup between layer and engine |

--- a/docs/01-architecture-overview.md
+++ b/docs/01-architecture-overview.md
@@ -55,7 +55,7 @@ Defined in `src/redis_server.cpp` / `src/redis_service.cpp`; engine flags are li
 | `cluster_mode` | — | strict Redis Cluster compatibility behavior |
 | `txn_isolation_level` / `protocol` / `isolation_level` | — | engine isolation/cc-protocol selection for txs ([02](02-command-processing.md)) |
 | `retry_on_occ_error` | — | auto-retry policy for OCC conflicts |
-| `enable_tls` / `tls_cert_file` / `tls_key_file` | off | optional TLS alongside plaintext on the RESP port |
+| `enable_tls` / `require_tls` / `tls_cert_file` / `tls_key_file` | off | TLS on the RESP port; optional alongside plaintext unless `require_tls=true` |
 | `slow_log_threshold` / `slow_log_max_length` | — | SLOWLOG |
 | `enable_redis_stats`, `enable_cmd_sort` | — | INFO/stats behavior |
 | `cc_notify` | — | notify-based (vs polling) wakeup between layer and engine |

--- a/docs/02-command-processing.md
+++ b/docs/02-command-processing.md
@@ -34,24 +34,25 @@ service layer only; engine internals are in `data_substrate/docs/` (esp. `02-thr
    (`src/redis_server.cpp:152-423`; reverse mapping `TxPortToRedisPort`,
    `include/redis_service.h:185`).
 2. `DataSubstrate::Instance().Init(config_file)` then `EnableEngine(TableEngine::EloqKv)`.
-3. `RedisServiceImpl::Init()` (`src/redis_service.cpp:219`) — *before* the engine starts:
+3. `RedisServiceImpl::Init()` (`src/redis_service.cpp:237`) — *before* the engine starts:
    registers the EloqKv engine with `DataSubstrate::RegisterEngine` along with prebuilt tables
    (`data_table_0..N-1` for `databases` logical DBs, default 16, plus the two namespace tables
    `__ns_0` and `ns_data_0`; `src/redis_service.cpp:232-281`), the catalog factory, per-command
    metric definitions, and the pub/sub publish callback. It also parses isolation/protocol flags
-   (§3), TLS settings (`enable_tls`, `tls_cert_file`, `tls_key_file`; TLS forces io_uring off,
-   `src/redis_service.cpp:528-531`), and builds the command table via `AddHandlers()`.
+   (§3), TLS settings (`enable_tls`, `require_tls`, `tls_cert_file`, `tls_key_file`; TLS forces
+   io_uring off, `src/redis_service.cpp:532-616`), and builds the command table via
+   `AddHandlers()`.
 4. `DataSubstrate::Instance().Start()` — engine up (TxService, store handler, log service).
-5. `RedisServiceImpl::Start()` (`src/redis_service.cpp:635`) — second phase: grabs
+5. `RedisServiceImpl::Start()` (`src/redis_service.cpp:666`) — second phase: grabs
    `TxService`/`DataStoreHandler` pointers, sizes per-core slow-log structures, computes the
    listen address, starts the metrics collector thread and namespace GC daemon. In `bootstrap`
-   mode it exits the process right here after table creation (`src/redis_service.cpp:704-721`).
+   mode it exits the process right here after table creation (`src/redis_service.cpp:734-751`).
 6. brpc `Server::Start()` with `server_options.redis_service = redis_service_impl` (ownership
    transfers to the server), the public listener declared Redis-only, `redis_max_connections` set
-   from `maxclients`, and optional TLS settings. TLS-enabled listeners accept both TLS and
-   plaintext RESP connections for rolling-upgrade compatibility. When `admin_port` is nonzero, a
-   second
-   Redis-only `brpc::Server` starts on the same bind address with an independent
+   from `maxclients`, and TLS settings. TLS-enabled listeners accept both TLS and plaintext RESP
+   connections for rolling-upgrade compatibility by default. Setting `require_tls=true` rejects
+   plaintext before Redis authentication or command processing. When `admin_port` is nonzero, a
+   second Redis-only `brpc::Server` starts on the same bind address with an independent
    `admin_maxclients` limit. Its non-owning service proxy forwards connection-context creation and
    every command to the primary `RedisServiceImpl`, so command, authentication, namespace, and TLS
    behavior remain shared. The primary server then waits in `RunUntilAskedToQuit()`

--- a/docs/02-command-processing.md
+++ b/docs/02-command-processing.md
@@ -48,7 +48,9 @@ service layer only; engine internals are in `data_substrate/docs/` (esp. `02-thr
    mode it exits the process right here after table creation (`src/redis_service.cpp:704-721`).
 6. brpc `Server::Start()` with `server_options.redis_service = redis_service_impl` (ownership
    transfers to the server), the public listener declared Redis-only, `redis_max_connections` set
-   from `maxclients`, and optional force-SSL settings. When `admin_port` is nonzero, a second
+   from `maxclients`, and optional TLS settings. TLS-enabled listeners accept both TLS and
+   plaintext RESP connections for rolling-upgrade compatibility. When `admin_port` is nonzero, a
+   second
    Redis-only `brpc::Server` starts on the same bind address with an independent
    `admin_maxclients` limit. Its non-owning service proxy forwards connection-context creation and
    every command to the primary `RedisServiceImpl`, so command, authentication, namespace, and TLS
@@ -122,7 +124,7 @@ update only the primary listener, preserving the independent escape path. Both l
 the same process file-descriptor limit and bthread/engine resources: deployments must leave FD
 headroom above `maxclients + admin_maxclients`, and the second listener does not guarantee access
 after process-wide FD, memory, CPU, or scheduler exhaustion. The administrative port inherits the
-primary bind address, authentication, and force-TLS configuration and exposes the same command
+primary bind address, authentication, and TLS configuration and exposes the same command
 dispatcher; protect it with host/network access controls.
 
 One `RedisConnectionContext` per admitted socket, created by `NewConnectionContext`

--- a/eloqkv.ini
+++ b/eloqkv.ini
@@ -78,6 +78,14 @@ enable_wal = off
 # not process any commands from clients that are not authenticated.
 # requirepass=
 
+# Enable TLS on the Redis listener. By default, TLS and plaintext connections
+# are both accepted for rolling-upgrade compatibility. Set require_tls=true to
+# reject plaintext connections. require_tls=true requires enable_tls=true.
+# enable_tls=false
+# require_tls=false
+# tls_cert_file=
+# tls_key_file=
+
 # Redo Log group servers configuration when deploying log servers separately.
 # The txlog_service_list should include all the redo log groups, with each entry
 # formatted as ip:port and separated by commas.

--- a/include/redis_service.h
+++ b/include/redis_service.h
@@ -254,6 +254,10 @@ public:
     {
         return enable_tls_;
     }
+    bool IsTlsRequired() const
+    {
+        return require_tls_;
+    }
     const std::string &GetTlsCertFile() const
     {
         return tls_cert_file_;
@@ -653,6 +657,7 @@ private:
 
     // TLS configuration
     bool enable_tls_{false};
+    bool require_tls_{false};
     std::string tls_cert_file_;
     std::string tls_key_file_;
 

--- a/src/redis_server.cpp
+++ b/src/redis_server.cpp
@@ -125,14 +125,16 @@ void ConfigureRedisListener(brpc::ServerOptions *options,
         return;
     }
 
-    options->force_ssl = true;
+    // Keep TLS optional on the Redis listener so existing plaintext clients
+    // remain compatible during rolling upgrades. Clients that initiate TLS
+    // still use the certificate configured below.
     brpc::ServerSSLOptions *ssl_options = options->mutable_ssl_options();
     ssl_options->default_cert.certificate = redis_service->GetTlsCertFile();
     ssl_options->default_cert.private_key = redis_service->GetTlsKeyFile();
 
-    LOG(INFO) << "TLS enabled for " << listener_name
-              << " Redis listener. Certificate: "
-              << redis_service->GetTlsCertFile()
+    LOG(INFO) << "Optional TLS enabled for " << listener_name
+              << " Redis listener; plaintext connections remain accepted. "
+              << "Certificate: " << redis_service->GetTlsCertFile()
               << ", Key: " << redis_service->GetTlsKeyFile();
 }
 

--- a/src/redis_server.cpp
+++ b/src/redis_server.cpp
@@ -125,15 +125,19 @@ void ConfigureRedisListener(brpc::ServerOptions *options,
         return;
     }
 
-    // Keep TLS optional on the Redis listener so existing plaintext clients
-    // remain compatible during rolling upgrades. Clients that initiate TLS
-    // still use the certificate configured below.
+    // Optional TLS preserves plaintext client compatibility during rolling
+    // upgrades. Secure deployments can require TLS and reject plaintext before
+    // Redis authentication or command processing.
+    options->force_ssl = redis_service->IsTlsRequired();
     brpc::ServerSSLOptions *ssl_options = options->mutable_ssl_options();
     ssl_options->default_cert.certificate = redis_service->GetTlsCertFile();
     ssl_options->default_cert.private_key = redis_service->GetTlsKeyFile();
 
-    LOG(INFO) << "Optional TLS enabled for " << listener_name
-              << " Redis listener; plaintext connections remain accepted. "
+    LOG(INFO) << (redis_service->IsTlsRequired() ? "Required" : "Optional")
+              << " TLS enabled for " << listener_name << " Redis listener; "
+              << (redis_service->IsTlsRequired()
+                      ? "plaintext connections are rejected. "
+                      : "plaintext connections remain accepted. ")
               << "Certificate: " << redis_service->GetTlsCertFile()
               << ", Key: " << redis_service->GetTlsKeyFile();
 }

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -533,9 +533,10 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
     enable_tls_ = !CheckCommandLineFlagIsDefault("enable_tls")
                       ? FLAGS_enable_tls
                       : config_reader.GetBoolean("local", "enable_tls", false);
-    require_tls_ = !CheckCommandLineFlagIsDefault("require_tls")
-                       ? FLAGS_require_tls
-                       : config_reader.GetBoolean("local", "require_tls", false);
+    require_tls_ =
+        !CheckCommandLineFlagIsDefault("require_tls")
+            ? FLAGS_require_tls
+            : config_reader.GetBoolean("local", "require_tls", false);
 
     if (require_tls_ && !enable_tls_)
     {

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -144,6 +144,9 @@ DEFINE_string(
 DEFINE_bool(retry_on_occ_error, true, "Retry transaction on OCC caused error.");
 
 DEFINE_bool(enable_tls, false, "Enable TLS for brpc RPC connections");
+DEFINE_bool(require_tls,
+            false,
+            "Reject plaintext Redis connections when TLS is enabled");
 DEFINE_string(tls_cert_file, "", "Path to TLS certificate file (PEM format)");
 DEFINE_string(tls_key_file, "", "Path to TLS private key file (PEM format)");
 
@@ -530,6 +533,16 @@ bool RedisServiceImpl::Init(brpc::Server &brpc_server)
     enable_tls_ = !CheckCommandLineFlagIsDefault("enable_tls")
                       ? FLAGS_enable_tls
                       : config_reader.GetBoolean("local", "enable_tls", false);
+    require_tls_ = !CheckCommandLineFlagIsDefault("require_tls")
+                       ? FLAGS_require_tls
+                       : config_reader.GetBoolean("local", "require_tls", false);
+
+    if (require_tls_ && !enable_tls_)
+    {
+        LOG(ERROR) << "require_tls cannot be enabled when TLS is disabled. "
+                      "Please set enable_tls=true.";
+        return false;
+    }
 
     if (enable_tls_)
     {


### PR DESCRIPTION
## Context

EloqKV 1.3.5 set `ServerOptions::force_ssl` while refactoring Redis listener admission for `maxclients`. Existing deployments already used `enable_tls=true` with both plaintext and TLS clients on EloqKV 1.3.4. During a rolling upgrade, promoting the first 1.3.5 standby therefore caused existing plaintext clients and older control tools to be reset.

At the same time, deployments that have completed their client migration need a fail-closed mode that prevents AUTH credentials and RESP traffic from crossing the network in plaintext.

## Behavior before and after

Before: `enable_tls=true` configured certificates and required TLS on both the primary and administrative Redis listeners. Plaintext RESP connections were reset, breaking the pre-1.3.5 rolling-upgrade path.

After:

- `enable_tls=false` keeps the listener plaintext-only; setting `require_tls=true` in this state is rejected at startup.
- `enable_tls=true, require_tls=false` accepts TLS and plaintext RESP on the same listener for rolling-upgrade compatibility.
- `enable_tls=true, require_tls=true` rejects plaintext connections at the brpc listener before Redis authentication or command processing.

Both Redis listeners share the selected policy, and TLS clients continue to use the configured certificate and key.

## Implementation

- Add the `require_tls` gflag/INI setting, defaulting to `false`, and validate that it is only used with `enable_tls=true`.
- Set `ServerOptions::force_ssl` from `RedisServiceImpl::IsTlsRequired()` in `ConfigureRedisListener`.
- Log whether each listener is running in optional- or required-TLS mode.
- Document the configuration matrix in `eloqkv.ini` and the architecture/command-processing documentation.

## Design decisions and alternatives

A separate boolean preserves the existing `enable_tls` setting and makes the patch safe for rolling upgrades: current configurations become optional-TLS without requiring a coordinated config rollout. Security-sensitive deployments can explicitly set `require_tls=true` once all clients use TLS. Rejecting `require_tls=true` without `enable_tls=true` avoids silently accepting plaintext after an invalid configuration.

The alternative of retaining unconditional `force_ssl` preserves fail-closed behavior but recreates the 1.3.4-to-1.3.5 compatibility break.

## Test plan

- [ ] Unit/TCL tests
- [x] Integration or manual validation
- [ ] Formatting/build checks
- [x] Compatibility validation

Commands and results:

```text
git diff --check origin/main...HEAD
passed

Release-binary A/B validation with identical enable_tls=true configuration:
1.3.4: plaintext PING succeeded; TLS PING succeeded
1.3.5: plaintext PING was reset; TLS PING succeeded
```

The current host does not have `cmake` or `clang-format-18`, so a local EloqKV build, TCL suite, repository formatter, and runtime validation of the new `require_tls` mode were not run. GitHub CI is the authoritative build and formatting check.

## Risk assessment

`require_tls` defaults to `false`, so existing `enable_tls=true` configurations accept plaintext until operators explicitly enable required-TLS mode. This is intentional for rolling-upgrade compatibility but must be accounted for by deployments that require encrypted transport. Required-TLS uses brpc listener enforcement before AUTH/RESP dispatch; its behavior depends on the pinned brpc implementation of `force_ssl`.

## Rollback plan

Revert this PR to restore unconditional forced TLS. Before rollback, migrate every Redis client and control-plane operation to TLS to avoid connection resets.

## Reviewer guide

Review TLS parsing and validation in `RedisServiceImpl::Init`, then `ConfigureRedisListener`, where `require_tls` is mapped to brpc `force_ssl`. Both the primary and administrative listeners call this helper. Finally verify that `eloqkv.ini` and the two design documents describe the same configuration matrix.

## Follow-up work

Add an integration test covering plaintext and TLS connections in optional- and required-TLS modes for both listener types.
