### PR TITLE
fix: avoid doubling large SET serialization buffers

### DIFF
--- a/docs/03-data-model.md
+++ b/docs/03-data-model.md
@@ -50,6 +50,13 @@ Lifecycle of e.g. `SET k v` (cross-ref [02-command-processing.md](02-command-pro
 3. On commit, `cmd->CommitOn(obj)` applies the mutation via the object's `Commit*` helpers (`CommitHset`, `CommitSAdd`, ...) and returns the resulting object pointer — possibly a *different* object (TTL twin added/removed) or `nullptr` for "now deleted" (`DelCommand::CommitOn`, and any `ModifiedToEmpty` path such as `SAddCommand::CommitOn` returning nullptr when the set empties).
 4. `OutputResult` renders `result_` to the client.
 
+`SetCommand::Serialize` appends the command type, flags, value length, value,
+and expiration timestamp in that order. It reserves space for the complete
+image, including any existing destination prefix and the trailing timestamp,
+before appending. This avoids growing a large value buffer a second time just
+to add the timestamp, without changing the command format used by replication
+and WAL replay.
+
 Key predicates as EloqKV implements them:
 
 | Predicate | Meaning here | Examples |

--- a/src/redis_command.cpp
+++ b/src/redis_command.cpp
@@ -43,6 +43,7 @@
 #include <random>
 #include <shared_mutex>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -1439,13 +1440,24 @@ txservice::TxObject *SetCommand::CommitOn(txservice::TxObject *obj_ptr)
 
 void SetCommand::Serialize(std::string &str) const
 {
+    std::string_view value_view = value_.StringView();
+    uint32_t len = value_view.size();
+    constexpr size_t fixed_size =
+        sizeof(uint8_t) + sizeof(int32_t) + sizeof(uint32_t) + sizeof(uint64_t);
+    const size_t available = str.max_size() - str.size();
+    if (available < fixed_size || len > available - fixed_size)
+    {
+        throw std::length_error(
+            "SET command image exceeds string maximum size");
+    }
+    // Include the trailing TTL so appending it cannot double a large buffer.
+    str.reserve(str.size() + fixed_size + len);
+
     uint8_t cmd_type = static_cast<uint8_t>(RedisCommandType::SET);
     str.append(reinterpret_cast<const char *>(&cmd_type), sizeof(uint8_t));
 
     auto *flag_ptr = reinterpret_cast<const char *>(&flag_);
     str.append(flag_ptr, sizeof(int32_t));
-    std::string_view value_view = value_.StringView();
-    uint32_t len = value_view.size();
     str.append(reinterpret_cast<const char *>(&len), sizeof(uint32_t));
     str.append(value_view.data(), len);
     str.append(reinterpret_cast<const char *>(&obj_expire_ts_),

--- a/tests/unit/eloq/object_serialize_deserialize_test.cpp
+++ b/tests/unit/eloq/object_serialize_deserialize_test.cpp
@@ -3,6 +3,7 @@
 #include <time.h>
 
 #include <catch2/catch_all.hpp>
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -27,6 +28,77 @@ struct Rob
         return M;
     }
 };
+
+TEST_CASE("SET serialization preserves the command image and prefix",
+          "[set-serialization]")
+{
+    const size_t value_size = GENERATE(size_t{0},
+                                       size_t{1},
+                                       size_t{15},
+                                       size_t{16},
+                                       size_t{1024},
+                                       size_t{1 << 20});
+    const std::string prefix = GENERATE(std::string{}, std::string("p\0fx", 4));
+    std::string value(value_size, 'v');
+    if (!value.empty())
+    {
+        value[value.size() / 2] = '\0';
+    }
+    const int32_t flags = OBJ_SET_EX | OBJ_SET_XX;
+    const uint64_t expiry = 1788869029841;
+    EloqKV::SetCommand command(value, flags, expiry);
+    std::string image = prefix;
+    command.Serialize(image);
+
+    // Encode the established wire layout independently, including embedded
+    // NULs.
+    const uint8_t type = static_cast<uint8_t>(EloqKV::RedisCommandType::SET);
+    const uint32_t length = value.size();
+    std::string expected = prefix;
+    expected.append(reinterpret_cast<const char *>(&type), sizeof(type));
+    expected.append(reinterpret_cast<const char *>(&flags), sizeof(flags));
+    expected.append(reinterpret_cast<const char *>(&length), sizeof(length));
+    expected.append(value);
+    expected.append(reinterpret_cast<const char *>(&expiry), sizeof(expiry));
+    REQUIRE(image == expected);
+
+    EloqKV::SetCommand replay;
+    replay.Deserialize(std::string_view(image).substr(prefix.size() + 1));
+    REQUIRE(replay.value_.StringView() == value);
+    REQUIRE(replay.flag_ == flags);
+    REQUIRE(replay.obj_expire_ts_ == expiry);
+}
+
+TEST_CASE("SET serialization reserves the complete large image",
+          "[set-serialization]")
+{
+    const std::string prefix = GENERATE(std::string{}, std::string(127, 'p'));
+    const std::string value(1 << 20, 'v');
+    EloqKV::SetCommand command(value);
+    const size_t image_size = sizeof(uint8_t) + sizeof(int32_t) +
+                              sizeof(uint32_t) + value.size() +
+                              sizeof(uint64_t);
+    std::string image = prefix;
+    std::string reserved = prefix;
+    reserved.reserve(prefix.size() + image_size);
+    command.Serialize(image);
+
+    REQUIRE(image.size() == prefix.size() + image_size);
+    // Compare against this standard library's reserve behavior, not a fixed
+    // allocator size class. Without the reservation, the trailing TTL grows
+    // the 1 MiB image a second time.
+    REQUIRE(image.capacity() == reserved.capacity());
+
+    image.reserve(image.size() + image_size);
+    const char *reserved_data = image.data();
+    const size_t reserved_capacity = image.capacity();
+    command.Serialize(image);
+    REQUIRE(image.size() == prefix.size() + 2 * image_size);
+    REQUIRE(image.data() == reserved_data);
+    REQUIRE(image.capacity() == reserved_capacity);
+    REQUIRE(std::string_view(image).substr(prefix.size(), image_size) ==
+            std::string_view(image).substr(prefix.size() + image_size));
+}
 
 TEST_CASE("zset_object-string")
 {


### PR DESCRIPTION
## Context

Large SET commands can occupy substantially more memory than their serialized length while queued for standby forwarding. `SetCommand::Serialize` appends the value before the trailing expiration timestamp; the final 8-byte append grows an otherwise complete large buffer again. On the tested libstdc++/custom mimalloc build, a 1 MiB value produces a 1,048,593-byte image but retains a 2,097,170-byte string capacity and a 2.5 MiB allocation.

## Behavior before and after

Reserve the complete appended image before writing any fields, including an existing destination prefix and the timestamp. The same 1 MiB SET then retains a 1,048,593-byte capacity and a 1.5 MiB allocation in the tested build. Command bytes and replay semantics are unchanged.

## Implementation

`SetCommand::Serialize` computes the fixed field overhead and existing 32-bit value length, checks the destination's remaining `max_size`, and reserves once. Existing serialization tests now cover binary and empty values, prefixes, repeated command appends, replay, and large-buffer capacity. The data-model documentation describes this allocation constraint.

## Design decisions and alternatives

The regression compares capacity with a single `std::string::reserve` using the same standard library rather than requiring a particular allocator size class. This PR changes only SET serialization in EloqKV; it does not update the engine submodule.

## Test plan

- [x] Unit/TCL tests — C++ serialization tests run; TCL suite not run.
- [x] Integration or manual validation — bounded local primary/standby experiments, with limitations below.
- [x] Formatting/build checks
- [x] Compatibility or performance validation — byte compatibility and allocation size; no throughput claim.

Commands and results:

```text
# Focused binaries compiled from the repository test source and production objects:
validation/before '[set-serialization]' --reporter compact
  Expected failures: both large-image capacity assertions (old production implementation).
validation/after '[set-serialization]' --reporter compact
  Passed: 60 assertions, 2 test cases.
validation/after --reporter compact
  Passed: 77 assertions, 13 test cases.
clang-format-18 --dry-run --Werror src/redis_command.cpp tests/unit/eloq/object_serialize_deserialize_test.cpp
git diff --check
  Passed.
```

An independent harness linked the actual baseline/fixed S3 production objects: 54 cases per version, identical wire digest, successful Deserialize round trips. It measured the retained allocation reduction from 2.5 to 1.5 MiB per 1 MiB SET.

The baseline S3 server and host_manager were built from EloqKV `de51634` / engine `f3c87df`; the fixed server reused the unchanged objects and relinked the freshly compiled `redis_command.cpp` object. Local experiments used four cores, epoll, WAL disabled, 512 incompressible 1 MiB values evenly distributed across CCSs, RedisCluster pipelines of 1/16/64/256/512 and four concurrent clients. Primary value checks passed. Sequential/pipelined cold GET controls also passed on the baseline. All isolated processes were stopped.

During the baseline 45-second continuous-write experiment, one simultaneous snapshot had CCS allocated memory of 391/138/152/144 MiB; the first CCS held approximately 100 MiB of serialized forwarding history, whose SET string allocations account for approximately 250 MiB. History draining restored balanced memory. The separate fixed continuous-write run peaked at approximately 291 MiB per CCS versus approximately 394 MiB in the baseline run, consistent with the reduced per-entry allocation; scheduling and command counts differed, so this is not a throughput benchmark.

The fixed stress run triggered standby resubscriptions. An immediate standby read failed while it was a candidate; after its caught-up transition, a separate connection verified all 512 values byte-for-byte. The initial failure is retained in the validation record. Baseline and fixed tests also encountered a pre-existing S3 file-cache downloader configuration mismatch, so these runs do not establish full storage-sync or failover health. No sanitizer suite was run.

## Risk assessment

The regression surface is destination capacity/exception timing; no field layout, version, or data migration changes. Exact allocated bytes depend on the allocator. This removes one demonstrated amplification mechanism; it does not establish that all production CCS skew is caused by it. Forwarding still uses a shared stream, and engine history accounting still measures logical serialized bytes rather than complete retained allocation.

## Rollback plan

Revert this PR; no data or configuration migration is needed.

## Reviewer guide

Start with `SetCommand::Serialize` and the two `[set-serialization]` cases. Check that the reserved length includes the destination prefix and trailing timestamp while the wire field order remains unchanged.

## Follow-up work

Audit retained-memory accounting and fairness/backpressure of standby forwarding separately. Investigate the S3 downloader's OSS URL/legacy configuration mismatch separately. Match production per-CCS history counters to its memory samples before declaring the reported production imbalance fully resolved.
