### PR TITLE
fix: release Pub/Sub reply arenas after serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,10 @@ if(${BUILD_WITH_TESTS})
     target_link_libraries(command_replay_test PRIVATE Catch2::Catch2WithMain ${ABSEIL} ${LOG_LIB} ${RESELOQ_LIBRARY} lua fpconv ${DYNAMIC_LIB})
 
     add_test(NAME command_replay_test COMMAND command_replay_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+    add_executable(pubsub_reply_lifetime_test ./tests/unit/eloq/pubsub_reply_lifetime_test.cpp ${RESELOQ_RESOURCES})
+    target_link_libraries(pubsub_reply_lifetime_test PRIVATE Catch2::Catch2WithMain ${ABSEIL} ${LOG_LIB} ${RESELOQ_LIBRARY} lua fpconv ${DYNAMIC_LIB})
+    add_test(NAME pubsub_reply_lifetime_test COMMAND pubsub_reply_lifetime_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     enable_testing()
 
     if (VECTOR_INDEX_ENABLED)

--- a/docs/04-scripting-pubsub-blocking.md
+++ b/docs/04-scripting-pubsub-blocking.md
@@ -39,7 +39,10 @@ subscriptions. It holds raw connection-context pointers under its mutex, while
 each connection mirrors its memberships so unsubscribe replies and disconnect
 cleanup can remove them. Subscription acknowledgements and published messages
 are serialized as RESP2 arrays and written directly to the socket through the
-connection context.
+connection context. The registry mutex protects reply construction and
+flushing. Serialization transfers bytes into an owning socket buffer; the
+source reply and its arena are then released even when a write is queued or
+fails. This output lifetime is independent of brpc's incoming-command parser.
 
 Publishing has two paths:
 

--- a/include/redis_connection_context.h
+++ b/include/redis_connection_context.h
@@ -93,6 +93,8 @@ public:
 
     brpc::RedisReply *GetOutput();
 
+    // Serialize and release the current reply before submitting its bytes to
+    // the socket. Callers must serialize access to output and its arena.
     bool FlushOutput();
 
     // Cache cursor content and return a hash key to fetch next.

--- a/src/redis_connection_context.cpp
+++ b/src/redis_connection_context.cpp
@@ -102,6 +102,11 @@ bool RedisConnectionContext::FlushOutput()
     output.SerializeTo(&appender);
     butil::IOBuf sendbuf;
     appender.move_to(sendbuf);
+    // Serialization copies the reply into IOBuf-owned storage. Drop the
+    // source pointers before freeing their arena, even if Socket::Write fails
+    // or queues the bytes for an asynchronous write.
+    output.Reset();
+    arena.clear();
     CHECK(!sendbuf.empty());
     brpc::Socket::WriteOptions wopt;
     wopt.ignore_eovercrowded = true;

--- a/tests/unit/eloq/pubsub_reply_lifetime_test.cpp
+++ b/tests/unit/eloq/pubsub_reply_lifetime_test.cpp
@@ -1,0 +1,135 @@
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <catch2/catch_test_macros.hpp>
+#include <cerrno>
+#include <string>
+#include <string_view>
+
+#include "pub_sub_manager.h"
+#include "redis_connection_context.h"
+
+namespace
+{
+// No listener or database is needed: the production PubSubManager and
+// FlushOutput write to a real nonblocking brpc socket, including queued writes.
+class Subscriber
+{
+public:
+    Subscriber()
+    {
+        int fds[2];
+        REQUIRE(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, fds) == 0);
+        peer_ = fds[0];
+        brpc::SocketOptions options;
+        options.fd = fds[1];
+        brpc::SocketId id;
+        REQUIRE(brpc::Socket::Create(options, &id) == 0);
+        REQUIRE(brpc::Socket::Address(id, &socket_) == 0);
+        context.socket = socket_.get();
+        context.pub_sub_mgr = &manager;
+    }
+
+    ~Subscriber()
+    {
+        // Remove the manager's borrowed pointer before releasing the socket.
+        manager.UnsubscribeAll(&context);
+        context.subscribed_channels.clear();
+        context.subscribed_patterns.clear();
+        socket_->SetFailed();
+        close(peer_);
+    }
+
+    void ExpectBytes(const std::string &expected)
+    {
+        std::string received;
+        while (received.size() < expected.size())
+        {
+            pollfd fd{peer_, POLLIN, 0};
+            int ready;
+            do
+            {
+                ready = poll(&fd, 1, 5000);
+            } while (ready < 0 && errno == EINTR);
+            REQUIRE(ready == 1);
+            char bytes[16384];
+            ssize_t count = read(peer_, bytes, sizeof(bytes));
+            if (count < 0 && (errno == EAGAIN || errno == EINTR))
+            {
+                continue;
+            }
+            REQUIRE(count > 0);
+            received.append(bytes, count);
+        }
+        REQUIRE(received == expected);
+    }
+
+    EloqKV::PubSubManager manager;
+    EloqKV::RedisConnectionContext context;
+
+private:
+    int peer_{-1};
+    brpc::SocketUniquePtr socket_;
+};
+
+std::string Bulk(std::string_view value)
+{
+    return "$" + std::to_string(value.size()) + "\r\n" + std::string(value) +
+           "\r\n";
+}
+}  // namespace
+
+TEST_CASE("Pubsub replies survive source cleanup and connection reuse",
+          "[pubsub][memory]")
+{
+    Subscriber subscriber;
+    auto &context = subscriber.context;
+    subscriber.manager.Subscribe({"channel"}, &context);
+    subscriber.ExpectBytes("*3\r\n" + Bulk("subscribe") + Bulk("channel") +
+                           ":1\r\n");
+    REQUIRE(context.output.is_nil());
+
+    subscriber.manager.PSubscribe({"chan*"}, &context);
+    subscriber.ExpectBytes("*3\r\n" + Bulk("psubscribe") + Bulk("chan*") +
+                           ":2\r\n");
+    REQUIRE(context.output.is_nil());
+
+    // Each publish emits two replies. The first reply's source arena is
+    // reused while its large serialized payload may still be queued.
+    std::string payload(1024 * 1024, 'x');
+    payload[27] = '\0';
+    for (int iteration = 0; iteration < 32; ++iteration)
+    {
+        payload.back() = 'a' + iteration % 26;
+        REQUIRE(subscriber.manager.Publish("channel", payload) == 2);
+        REQUIRE(context.output.is_nil());
+        subscriber.ExpectBytes("*3\r\n" + Bulk("message") + Bulk("channel") +
+                               Bulk(payload) + "*4\r\n" + Bulk("pmessage") +
+                               Bulk("chan*") + Bulk("channel") + Bulk(payload));
+    }
+
+    subscriber.manager.Unsubscribe({"channel"}, &context);
+    subscriber.ExpectBytes("*3\r\n" + Bulk("unsubscribe") + Bulk("channel") +
+                           ":1\r\n");
+    subscriber.manager.PUnsubscribe({"chan*"}, &context);
+    subscriber.ExpectBytes("*3\r\n" + Bulk("punsubscribe") + Bulk("chan*") +
+                           ":0\r\n");
+    REQUIRE(context.output.is_nil());
+}
+
+TEST_CASE("Failed pubsub writes discard their source reply", "[pubsub][memory]")
+{
+    Subscriber subscriber;
+    auto &context = subscriber.context;
+    REQUIRE(context.socket->SetFailed() == 0);
+    for (int iteration = 0; iteration < 4; ++iteration)
+    {
+        context.output.SetArray(3);
+        context.output[0].SetString("message");
+        context.output[1].SetString("channel");
+        context.output[2].SetString(std::string(1024 * 1024, 'x'));
+        REQUIRE_FALSE(context.FlushOutput());
+        REQUIRE(context.output.is_nil());
+    }
+}


### PR DESCRIPTION
## Context

A long-lived Pub/Sub connection kept the arena allocations for every reply, including full message payloads, until disconnect. `FlushOutput()` serialized the reply but never reset the source arena.

## Behavior before and after

Each reply now releases its source allocation immediately after serialization, on successful and failed writes. Subscription confirmations, channel messages and pattern messages keep the same RESP bytes, including binary payloads.

## Implementation

Reset `output` and clear its arena after moving serialized bytes into the owning `IOBuf`, before `Socket::Write`. Document that callers must serialize access and that queued socket writes own their bytes independently.

## Design decisions and alternatives

The existing `IOBufAppender::append` copies reply data. Cleanup therefore belongs at the serialization boundary and does not wait for asynchronous socket completion. `RedisReply::Reset()` alone would leave the arena blocks allocated. The change uses the existing PubSubManager mutex and does not alter subscription bookkeeping.

## Test plan

- [x] Focused unit/socket regression
- [x] Independent Debug build and formatting
- [x] Direct arena ownership inspection in the test process
- [ ] Full Redis/TCL or HA suite
- [ ] Performance benchmark

```sh
export PATH=/opt/eloq/third_party/bin:$PATH
export LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64
cmake -S /tmp/eloq-pubsub-reply-pr.c7s993jf/src -B /tmp/eloq-pubsub-reply-pr.c7s993jf/bld -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_WITH_TESTS=ON -DWITH_TESTS=OFF -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 -DWITH_LOG_SERVICE=ON -DEXT_TX_PROC_ENABLED=ON -DELOQ_MODULE_ENABLED=ON -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party -DELOQ_THIRD_PARTY_REQUIRED=ON -DCMAKE_INSTALL_PREFIX=/tmp/eloq-pubsub-reply-pr.c7s993jf/install
cmake --build /tmp/eloq-pubsub-reply-pr.c7s993jf/bld --target pubsub_reply_lifetime_test --parallel 2
ctest --test-dir /tmp/eloq-pubsub-reply-pr.c7s993jf/bld -R '^pubsub_reply_lifetime_test$' --output-on-failure
clang-format-18 --dry-run --Werror src/redis_connection_context.cpp include/redis_connection_context.h tests/unit/eloq/pubsub_reply_lifetime_test.cpp
git diff --check
```

All commands passed on head `93eb06e`, based on parent `1c02c42` and engine `5c0be9f`. The new engine dependency closure was rebuilt after rebasing, and both the socket regression and the 72-flush arena inspection were rerun successfully. The two test cases exercise the actual PubSubManager and FlushOutput through a nonblocking brpc socketpair: 32 publishes each deliver a 1 MiB binary message to both a channel and a pattern subscription, followed by unsubscribe replies; a separate failed socket checks terminal cleanup. Received RESP bytes are compared exactly, after the source arena has already been reused.

An additional GDB run launched only this test executable, using unmodified type metadata to inspect arena block ownership at the production write boundary. All 72 flushes had zero arena blocks and zero owned bytes before `Socket::Write`; both test cases passed. The script and JSON results are preserved under `/tmp/eloq-pubsub-reply-pr.c7s993jf/`. This is arena ownership, not an RSS measurement. No sanitizer or database server was used.

## Risk assessment

The source must be reset only after serialization has copied it. The socket regression covers immediate failure and queued large writes. Arena allocations are now freed per message, adding allocator churn; no throughput benchmark was run. The existing teardown-versus-publish race is outside this patch.

## Rollback plan

Revert this PR. No protocol, configuration or persisted-data migration.

## Reviewer guide

Start at `RedisConnectionContext::FlushOutput`, then the socket regression and Pub/Sub lifecycle documentation. Confirm `output.Reset()` precedes `arena.clear()` and both precede the socket handoff.

## Follow-up work

The independent brpc incoming-command parser arena and Lua interpreter pool are outside this change. This PR does not claim Pub/Sub caused the reported SET/HSET workload's shard imbalance.
