### PR TITLE
fix: release pooled Lua call state and retire flushed script caches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,10 @@ option(BUILD_WITH_TESTS "Run unit-tests" OFF)
 if(${BUILD_WITH_TESTS})
     find_package(Catch2 REQUIRED)
 
+    add_executable(lua_lifetime_test ./tests/unit/eloq/lua_lifetime_test.cpp ${RESELOQ_RESOURCES})
+    target_link_libraries(lua_lifetime_test PRIVATE Catch2::Catch2WithMain ${ABSEIL} ${LOG_LIB} ${RESELOQ_LIBRARY} lua fpconv ${DYNAMIC_LIB})
+    add_test(NAME lua_lifetime_test COMMAND lua_lifetime_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
     add_executable(object_serialize_deserialize_test ./tests/unit/eloq/object_serialize_deserialize_test.cpp ${RESELOQ_RESOURCES})
     target_link_libraries(object_serialize_deserialize_test PRIVATE Catch2::Catch2WithMain ${ABSEIL} ${LOG_LIB} ${RESELOQ_LIBRARY} lua fpconv ${DYNAMIC_LIB})
 
@@ -534,6 +538,7 @@ if(${BUILD_WITH_TESTS})
     target_link_libraries(command_replay_test PRIVATE Catch2::Catch2WithMain ${ABSEIL} ${LOG_LIB} ${RESELOQ_LIBRARY} lua fpconv ${DYNAMIC_LIB})
 
     add_test(NAME command_replay_test COMMAND command_replay_test WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
     enable_testing()
 
     if (VECTOR_INDEX_ENABLED)

--- a/docs/04-scripting-pubsub-blocking.md
+++ b/docs/04-scripting-pubsub-blocking.md
@@ -18,6 +18,15 @@ Script source is cached by SHA in `RedisServiceImpl`. The cache and compiled
 interpreter functions are process-local, not replicated cluster state, so an
 `EVALSHA` request must reach a node that has learned the script body.
 
+`SCRIPT FLUSH` advances the script-cache generation and removes idle
+interpreters together with the source cache. Checked-out interpreters remain
+exclusively owned by their active attempts, but an obsolete generation cannot
+return to the pool. `EVALSHA` binds the resolved body to the generation observed
+at lookup, including across checkout and transaction retries; a request that
+resolved before a flush can finish without repopulating the current cache.
+Pool checkout, return, and flush share the cache mutex, which is released before
+discarded interpreters are destroyed.
+
 Each `EVAL`/`EVALSHA` attempt creates one transaction using the transaction
 isolation/protocol configuration. `redis.call` and `redis.pcall` re-enter
 `RedisServiceImpl::GenericCommand` with that same txm and auto-commit disabled.
@@ -31,6 +40,17 @@ by `GenericCommand` are available from scripts. Nested scripting and
 transaction-control commands are outside this model. Direct commands such as
 `PUBLISH` do not become transactional merely because they are invoked by a
 script.
+
+The transaction hook is revoked before commit or abort can recycle the txm.
+After reply conversion or a failed attempt, interpreter reset removes the
+stack and argument roots and collects large completed-call allocations before
+pool return. User finalizers can run during collection, so reset runs within a
+protected Lua call with the Redis hook disabled. A finalizer error discards the
+interpreter instead of returning it to the pool; destruction also revokes the
+hook before closing the VM. Automatic collection is restricted to protected
+script execution and cleanup, and is stopped during native argument
+preparation, reply conversion, and idle time. This lifetime boundary does not
+impose a finalizer execution-time limit or a cap on live script caches.
 
 ## Pub/Sub
 
@@ -88,6 +108,8 @@ through the Lua bridge.
 
 - All transactional calls made by one script attempt share one txm; an OCC
   retry restarts the whole script.
+- Completed script attempts cannot retain a callable transaction hook in the
+  interpreter pool, and obsolete cache generations cannot re-enter that pool.
 - Pub/Sub lifetime is tied to connection cleanup, but delivery is neither
   durable nor part of a Redis data transaction.
 - Pub/Sub channel names are not scoped by database or namespace.
@@ -103,6 +125,7 @@ through the Lua bridge.
 | Lua runtime, sandbox, Redis bridge, and value conversion | `include/lua_interpreter.h`, `src/lua_interpreter.cpp`, `include/lua_output_handler.h` |
 | Interpreter pool, script cache, transaction/retry loop, and `GenericCommand` bridge | `include/redis_service.h`, `src/redis_service.cpp`, `src/redis_handler.cpp` |
 | Script behavior exercised through the Redis interface | `tests/unit/eloq/scripting.tcl` |
+| Completed-call memory, finalizer safety, and script-cache generation lifetimes | `tests/unit/eloq/lua_lifetime_test.cpp` |
 | Process-local subscriptions, direct socket output, and disconnect cleanup | `include/pub_sub_manager.h`, `src/pub_sub_manager.cpp`, `include/redis_connection_context.h`, `src/redis_connection_context.cpp` |
 | Cross-node publish request and callback integration | `src/redis_service.cpp`, `data_substrate/tx_service/include/tx_request.h`, `data_substrate/tx_service/src/tx_execution.cpp`, `data_substrate/tx_service/src/cc/local_cc_shards.cpp` |
 | Pub/Sub observable behavior | `tests/unit/eloq/pubsub.tcl` |

--- a/include/lua_interpreter.h
+++ b/include/lua_interpreter.h
@@ -58,7 +58,11 @@ public:
 
     void LuaReplyToRedisReply(brpc::RedisReply *);
 
-    void CleanStack();
+    // Release completed-call roots after reply conversion or error handling.
+    // Collect large transient allocations before an interpreter becomes idle.
+    // A finalizer error makes the VM unsuitable for reuse; the caller must
+    // destroy it instead of returning it to the interpreter pool.
+    bool Reset();
 
     static void sha1hex(char *digest, const char *script, size_t len);
 
@@ -69,6 +73,9 @@ public:
     }
 
 private:
+    friend class RedisServiceImpl;
+    friend struct LuaInterpreterTestPeer;
+
     int RedisGenericCommand(bool raise_error);
 
     static int RedisCallCommand(lua_State *lua);
@@ -84,6 +91,11 @@ private:
     static void *GetFromRegistry(lua_State *lua, const char *name);
 
     lua_State *lua_;
+    size_t gc_baseline_bytes_{0};
+    size_t input_bytes_since_reset_{0};
+    // Protected by RedisServiceImpl::script_mutex_ when checking out/returning
+    // this interpreter; an active interpreter remains exclusively owned.
+    uint64_t script_cache_generation_{0};
 
     /* Recursive RedisGenericCommand calls detection. */
     // TODO(zkl): making this atomic?

--- a/include/redis_service.h
+++ b/include/redis_service.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>  //std::unique_ptr
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -296,9 +297,11 @@ public:
         TransactionExecution *txm,
         RedisConnectionContext *ctx);
 
-    bool EvalLua(const RedisConnectionContext *ctx,
-                 const std::vector<butil::StringPiece> &args,
-                 brpc::RedisReply *output);
+    bool EvalLua(
+        const RedisConnectionContext *ctx,
+        const std::vector<butil::StringPiece> &args,
+        brpc::RedisReply *output,
+        std::optional<uint64_t> resolved_script_generation = std::nullopt);
 
     store::DataStoreHandler *GetStoreHandler() const
     {
@@ -572,7 +575,10 @@ public:
                                     TemplateTxRequest<Subtype, T> *tx_req,
                                     OutputHandler *error);
 
-    std::unique_ptr<LuaInterpreter> GetLuaInterpreter();
+    // An EVALSHA request keeps the generation in which its body was resolved,
+    // even if FLUSH runs before checkout or between transaction retries.
+    std::unique_ptr<LuaInterpreter> GetLuaInterpreter(
+        std::optional<uint64_t> resolved_script_generation = std::nullopt);
 
     void CleanAndReturnLuaInterpreter(std::unique_ptr<LuaInterpreter>);
 
@@ -611,6 +617,9 @@ private:
 
     std::shared_mutex script_mutex_;
     std::unordered_map<std::string, std::string> scripts_;
+    // The same mutex serializes FLUSH with pool checkout/return. Interpreters
+    // active during FLUSH finish normally, then are discarded on return.
+    uint64_t script_cache_generation_{0};
 
     NamespaceManager namespace_manager_;
 

--- a/src/lua_interpreter.cpp
+++ b/src/lua_interpreter.cpp
@@ -50,6 +50,54 @@ extern "C"
 
 namespace EloqKV
 {
+namespace
+{
+constexpr size_t kLuaGcGrowthThreshold = 64 * 1024;
+
+size_t LuaMemoryBytes(lua_State *lua)
+{
+    return static_cast<size_t>(lua_gc(lua, LUA_GCCOUNT, 0)) * 1024 +
+           lua_gc(lua, LUA_GCCOUNTB, 0);
+}
+
+struct LuaResetContext
+{
+    size_t baseline_bytes;
+    bool large_input;
+    bool collected{false};
+};
+
+int ResetLuaState(lua_State *lua)
+{
+    auto *context = static_cast<LuaResetContext *>(lua_touserdata(lua, 1));
+    lua_settop(lua, 0);
+
+    // Finalizers execute user Lua too. Keep its global-table restrictions
+    // while allowing these raw C writes, which cannot invoke metamethods or
+    // take a GC step. Pushing the field names can take a GC step.
+    lua_enablereadonlytable(lua, LUA_GLOBALSINDEX, 1);
+    lua_pushliteral(lua, "KEYS");
+    lua_pushnil(lua);
+    lua_enablereadonlytable(lua, LUA_GLOBALSINDEX, 0);
+    lua_rawset(lua, LUA_GLOBALSINDEX);
+    lua_enablereadonlytable(lua, LUA_GLOBALSINDEX, 1);
+    lua_pushliteral(lua, "ARGV");
+    lua_pushnil(lua);
+    lua_enablereadonlytable(lua, LUA_GLOBALSINDEX, 0);
+    lua_rawset(lua, LUA_GLOBALSINDEX);
+    lua_enablereadonlytable(lua, LUA_GLOBALSINDEX, 1);
+
+    const size_t used_bytes = LuaMemoryBytes(lua);
+    if (context->large_input ||
+        (used_bytes > context->baseline_bytes &&
+         used_bytes - context->baseline_bytes > kLuaGcGrowthThreshold))
+    {
+        lua_gc(lua, LUA_GCCOLLECT, 0);
+        context->collected = true;
+    }
+    return 0;
+}
+}  // namespace
 
 int EVPDigest(const void *data,
               size_t datalen,
@@ -322,10 +370,17 @@ LuaInterpreter::LuaInterpreter()
     SaveOnRegistry(lua_, "interpreter", this);
 
     RegisterRedisAPI(lua_);
+    lua_gc(lua_, LUA_GCCOLLECT, 0);
+    gc_baseline_bytes_ = LuaMemoryBytes(lua_);
+    lua_gc(lua_, LUA_GCSTOP, 0);
 }
 
 LuaInterpreter::~LuaInterpreter()
 {
+    // lua_close runs finalizers, including on VMs discarded without Reset.
+    // Their Redis calls must never use a completed transaction's hook.
+    script_call_ = {};
+    lua_enablereadonlytable(lua_, LUA_GLOBALSINDEX, 1);
     lua_close(lua_);
 }
 
@@ -382,6 +437,13 @@ void LuaInterpreter::SetGlobalArray(const char *name,
     lua_newtable(lua_);
     for (size_t j = 0; j < args.size(); j++)
     {
+        // Saturate once large input requires a collection. Net VM growth is
+        // insufficient when automatic GC has lowered usage below an older
+        // full-collection baseline.
+        input_bytes_since_reset_ =
+            std::min(kLuaGcGrowthThreshold + 1,
+                     input_bytes_since_reset_ +
+                         std::min(args[j].size(), kLuaGcGrowthThreshold + 1));
         lua_pushlstring(lua_, args[j].data(), args[j].size());
         lua_rawseti(lua_, -2, j + 1);
     }
@@ -415,7 +477,12 @@ bool LuaInterpreter::CallFunction(std::string_view sha, std::string *error)
         return false;
     }
     lua_enablereadonlytable(lua_, LUA_GLOBALSINDEX, 1);
+    // Only protected Lua execution may run user finalizers. Native argument
+    // setup and reply conversion can allocate too, but have no Lua error
+    // boundary and may run after the transaction has already completed.
+    lua_gc(lua_, LUA_GCRESTART, 0);
     int err = lua_pcall(lua_, 0, 1, -2);
+    lua_gc(lua_, LUA_GCSTOP, 0);
     lua_enablereadonlytable(lua_, LUA_GLOBALSINDEX, 0);
 
     if (err)
@@ -544,9 +611,29 @@ void LuaInterpreter::LuaReplyToRedisReply(brpc::RedisReply *output)
     lua_pop(lua_, 1);
 }
 
-void LuaInterpreter::CleanStack()
+bool LuaInterpreter::Reset()
 {
+    script_call_ = {};
     lua_settop(lua_, 0);
+    LuaResetContext context{gc_baseline_bytes_,
+                            input_bytes_since_reset_ > kLuaGcGrowthThreshold};
+    // lua_cpcall establishes protection before allocating its C closure.
+    // A bare lua_gc, or even lua_pushcfunction before lua_pcall, can otherwise
+    // let a user __gc error reach Lua's panic/exit path outside a script call.
+    const int status = lua_cpcall(lua_, ResetLuaState, &context);
+    lua_gc(lua_, LUA_GCSTOP, 0);
+    lua_enablereadonlytable(lua_, LUA_GLOBALSINDEX, 0);
+    lua_settop(lua_, 0);
+    input_bytes_since_reset_ = 0;
+    if (status != 0)
+    {
+        return false;
+    }
+    if (context.collected)
+    {
+        gc_baseline_bytes_ = LuaMemoryBytes(lua_);
+    }
+    return true;
 }
 
 /*

--- a/src/lua_interpreter.cpp
+++ b/src/lua_interpreter.cpp
@@ -614,6 +614,8 @@ void LuaInterpreter::LuaReplyToRedisReply(brpc::RedisReply *output)
 bool LuaInterpreter::Reset()
 {
     script_call_ = {};
+    // Lua's non-local error exit can skip RedisGenericCommand's decrement.
+    redis_cmd_in_use_ = 0;
     lua_settop(lua_, 0);
     LuaResetContext context{gc_baseline_bytes_,
                             input_bytes_since_reset_ > kLuaGcGrowthThreshold};

--- a/src/redis_connection_context.cpp
+++ b/src/redis_connection_context.cpp
@@ -59,7 +59,12 @@ RedisConnectionContext::~RedisConnectionContext()
         AbortTx(txm);
     }
 
-    RedisStats::IncrConnClosed();
+    // Internal contexts (including pooled Lua VMs) have no client socket and
+    // never increment the received-connection counter.
+    if (socket != nullptr)
+    {
+        RedisStats::IncrConnClosed();
+    }
 }
 
 void RedisConnectionContext::SubscribeChannel(std::string_view chan)

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -1386,22 +1386,37 @@ bool RedisServiceImpl::SendTxRequest(TransactionExecution *txm,
     return true;
 }
 
-std::unique_ptr<LuaInterpreter> RedisServiceImpl::GetLuaInterpreter()
+std::unique_ptr<LuaInterpreter> RedisServiceImpl::GetLuaInterpreter(
+    std::optional<uint64_t> resolved_script_generation)
 {
+    std::shared_lock<std::shared_mutex> lock(script_mutex_);
     std::unique_ptr<LuaInterpreter> interpreter;
-    bool success = lua_interpreters_.try_dequeue(interpreter);
+    const uint64_t generation =
+        resolved_script_generation.value_or(script_cache_generation_);
+    // A request resolved before FLUSH may still finish, but its old body must
+    // not enter a current-generation VM or repopulate the interpreter cache.
+    const bool success = generation == script_cache_generation_ &&
+                         lua_interpreters_.try_dequeue(interpreter);
     if (!success)
     {
-        return std::make_unique<LuaInterpreter>();
+        interpreter = std::make_unique<LuaInterpreter>();
     }
+    interpreter->script_cache_generation_ = generation;
     return interpreter;
 }
 
 void RedisServiceImpl::CleanAndReturnLuaInterpreter(
     std::unique_ptr<LuaInterpreter> lua_state)
 {
-    lua_state->CleanStack();
-    lua_interpreters_.enqueue(std::move(lua_state));
+    if (!lua_state->Reset())
+    {
+        return;
+    }
+    std::shared_lock<std::shared_mutex> lock(script_mutex_);
+    if (lua_state->script_cache_generation_ == script_cache_generation_)
+    {
+        lua_interpreters_.enqueue(std::move(lua_state));
+    }
 }
 
 void RedisServiceImpl::AddHandlers()
@@ -2458,8 +2473,19 @@ TxErrorCode RedisServiceImpl::MultiExec(
 
 bool RedisServiceImpl::ScriptFlush()
 {
-    std::unique_lock<std::shared_mutex> lock(script_mutex_);
-    scripts_.clear();
+    std::vector<std::unique_ptr<LuaInterpreter>> retired;
+    std::unique_ptr<LuaInterpreter> interpreter;
+    {
+        std::unique_lock<std::shared_mutex> lock(script_mutex_);
+        scripts_.clear();
+        ++script_cache_generation_;
+        while (lua_interpreters_.try_dequeue(interpreter))
+        {
+            retired.emplace_back(std::move(interpreter));
+        }
+    }
+    // lua_close runs user finalizers. Destroy retired VMs after releasing the
+    // cache mutex, including when a finalizer reports an error.
     return true;
 }
 
@@ -2540,15 +2566,18 @@ bool RedisServiceImpl::Evalsha(const RedisConnectionContext *ctx,
     }
     std::vector<butil::StringPiece> eval_args = args;
     std::string script_body = iter->second;
+    const uint64_t resolved_script_generation = script_cache_generation_;
     eval_args[1] = script_body;
     lock.unlock();
 
-    return EvalLua(ctx, eval_args, output);
+    return EvalLua(ctx, eval_args, output, resolved_script_generation);
 }
 
-bool RedisServiceImpl::EvalLua(const RedisConnectionContext *ctx,
-                               const std::vector<butil::StringPiece> &args,
-                               brpc::RedisReply *output)
+bool RedisServiceImpl::EvalLua(
+    const RedisConnectionContext *ctx,
+    const std::vector<butil::StringPiece> &args,
+    brpc::RedisReply *output,
+    std::optional<uint64_t> resolved_script_generation)
 {
     // the script content stores in args[1]
     // 1. parse script and keys and args
@@ -2617,7 +2646,8 @@ bool RedisServiceImpl::EvalLua(const RedisConnectionContext *ctx,
         TransactionExecution *txm = NewTxm(txn_isolation_level_, txn_protocol_);
 
         // get lua lua_state
-        std::unique_ptr<LuaInterpreter> interpreter = GetLuaInterpreter();
+        std::unique_ptr<LuaInterpreter> interpreter =
+            GetLuaInterpreter(resolved_script_generation);
 
         // Populate the argv and keys table accordingly to the arguments that
         // EVAL received.
@@ -2659,6 +2689,9 @@ bool RedisServiceImpl::EvalLua(const RedisConnectionContext *ctx,
         }
         std::string error;
         bool ok = interpreter->CallFunction(sha, &error);
+        // The script is finished; CommitTx/AbortTx may recycle its txm before
+        // reply conversion or interpreter cleanup runs.
+        interpreter->SetScriptRedisHook(nullptr);
         if (!ok)
         {
             // abort tx

--- a/src/redis_service.cpp
+++ b/src/redis_service.cpp
@@ -2675,6 +2675,7 @@ bool RedisServiceImpl::EvalLua(
             const std::string &error_msg = result;
             output->SetError("ERR Error compiling script (new function): " +
                              error_msg);
+            interpreter->SetScriptRedisHook(nullptr);
             AbortTx(txm);
             CleanAndReturnLuaInterpreter(std::move(interpreter));
             return false;

--- a/tests/unit/eloq/lua_lifetime_test.cpp
+++ b/tests/unit/eloq/lua_lifetime_test.cpp
@@ -1,0 +1,403 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "lua_interpreter.h"
+#include "redis_service.h"
+
+extern "C"
+{
+#include "lua/src/lstate.h"
+}
+
+namespace EloqKV
+{
+struct LuaInterpreterTestPeer
+{
+    static size_t MemoryBytes(const LuaInterpreter &interpreter)
+    {
+        return G(interpreter.lua_)->totalbytes;
+    }
+
+    static size_t ScratchBufferBytes(const LuaInterpreter &interpreter)
+    {
+        return luaZ_sizebuffer(&G(interpreter.lua_)->buff);
+    }
+};
+}  // namespace EloqKV
+
+namespace
+{
+using EloqKV::LuaInterpreter;
+using EloqKV::LuaInterpreterTestPeer;
+
+void Evaluate(LuaInterpreter &interpreter,
+              std::string_view script,
+              brpc::RedisReply &reply)
+{
+    auto [ok, sha] = interpreter.CreateFunction(script);
+    REQUIRE(ok);
+    std::string error;
+    REQUIRE(interpreter.CallFunction(sha, &error));
+    interpreter.LuaReplyToRedisReply(&reply);
+}
+
+int64_t MemoryKiB(LuaInterpreter &interpreter)
+{
+    // A Lua script that reads collectgarbage('count') can itself advance GC.
+    // Peek at the real VM counter without executing Lua or changing GC state.
+    return LuaInterpreterTestPeer::MemoryBytes(interpreter) / 1024;
+}
+
+int64_t MemoryWithoutScratchKiB(LuaInterpreter &interpreter)
+{
+    // Lua 5.1 shrinks its shared string-building buffer by only half per GC
+    // cycle. Account for this workspace separately from retained Lua values.
+    return (LuaInterpreterTestPeer::MemoryBytes(interpreter) -
+            LuaInterpreterTestPeer::ScratchBufferBytes(interpreter)) /
+           1024;
+}
+
+void RequireNoArguments(LuaInterpreter &interpreter)
+{
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    Evaluate(interpreter,
+             "return rawget(_G, 'KEYS') == nil and rawget(_G, 'ARGV') == nil",
+             reply);
+    REQUIRE(reply.is_integer());
+    REQUIRE(reply.integer() == 1);
+}
+}  // namespace
+
+TEST_CASE("Lua reset releases large arguments after copying the reply",
+          "[lua][memory]")
+{
+    LuaInterpreter interpreter;
+    const int64_t baseline = MemoryKiB(interpreter);
+    std::string key(1024 * 1024, 'k');
+    std::string value(1024 * 1024, 'v');
+    value[31] = '\0';
+    std::vector<std::string_view> keys{key};
+    std::vector<std::string_view> args{value};
+
+    for (int iteration = 0; iteration < 4; ++iteration)
+    {
+        interpreter.SetGlobalArray("KEYS", keys);
+        interpreter.SetGlobalArray("ARGV", args);
+        butil::Arena arena;
+        brpc::RedisReply reply(&arena);
+        Evaluate(interpreter, "return {KEYS[1], ARGV[1]}", reply);
+        REQUIRE(MemoryKiB(interpreter) > baseline + 2000);
+        REQUIRE(interpreter.Reset());
+        REQUIRE(MemoryKiB(interpreter) < baseline + 128);
+        RequireNoArguments(interpreter);
+        REQUIRE(reply.is_array());
+        REQUIRE(reply[0].data().as_string() == key);
+        REQUIRE(reply[1].data().as_string() == value);
+    }
+}
+
+TEST_CASE("Lua reset releases error paths and call hooks", "[lua][memory]")
+{
+    LuaInterpreter interpreter;
+    const int64_t baseline = MemoryKiB(interpreter);
+    std::string value(1024 * 1024, 'v');
+    std::vector<std::string_view> args{value};
+    interpreter.SetGlobalArray("ARGV", args);
+    auto owner = std::make_shared<int>(1);
+    std::weak_ptr<int> observer = owner;
+    interpreter.SetScriptRedisHook([owner](auto *, const auto &, auto *) {});
+    owner.reset();
+
+    SECTION("runtime error")
+    {
+        auto [ok, sha] = interpreter.CreateFunction("error(ARGV[1])");
+        REQUIRE(ok);
+        std::string error;
+        REQUIRE_FALSE(interpreter.CallFunction(sha, &error));
+        REQUIRE(error.find(value) != std::string::npos);
+    }
+    SECTION("compile error")
+    {
+        REQUIRE_FALSE(interpreter.CreateFunction("return (").first);
+    }
+
+    REQUIRE(interpreter.Reset());
+    REQUIRE(observer.expired());
+    REQUIRE(MemoryWithoutScratchKiB(interpreter) < baseline + 128);
+    RequireNoArguments(interpreter);
+}
+
+TEST_CASE("Lua reset collects large script-created temporaries",
+          "[lua][memory]")
+{
+    LuaInterpreter interpreter;
+    const int64_t baseline = MemoryKiB(interpreter);
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    Evaluate(interpreter, "return string.rep('x', 1048576)", reply);
+    REQUIRE(reply.data().size() == 1024 * 1024);
+    const size_t scratch_before =
+        LuaInterpreterTestPeer::ScratchBufferBytes(interpreter);
+    REQUIRE(interpreter.Reset());
+    REQUIRE(MemoryWithoutScratchKiB(interpreter) < baseline + 128);
+    REQUIRE(LuaInterpreterTestPeer::ScratchBufferBytes(interpreter) <
+            scratch_before);
+    REQUIRE(reply.data().as_string() == std::string(1024 * 1024, 'x'));
+}
+
+TEST_CASE("Script flush discards idle compiled caches", "[lua][script-flush]")
+{
+    EloqKV::RedisServiceImpl service("", "test");
+    std::string script = "return '" + std::string(1024 * 1024, 'x') + "'";
+    butil::Arena arena;
+    brpc::RedisReply loaded(&arena);
+    REQUIRE(service.ScriptLoad({"script", "load", script}, &loaded));
+    const std::string sha = loaded.data().as_string();
+    auto interpreter = service.GetLuaInterpreter();
+    REQUIRE(MemoryKiB(*interpreter) > 1024);
+    service.CleanAndReturnLuaInterpreter(std::move(interpreter));
+    REQUIRE(service.ScriptFlush());
+
+    interpreter = service.GetLuaInterpreter();
+    REQUIRE(MemoryKiB(*interpreter) < 128);
+    std::string error;
+    REQUIRE_FALSE(interpreter->CallFunction(sha, &error));
+    brpc::RedisReply exists(&arena);
+    REQUIRE(service.ScriptExists({"script", "exists", sha}, &exists));
+    REQUIRE(exists[0].integer() == 0);
+    service.CleanAndReturnLuaInterpreter(std::move(interpreter));
+}
+
+TEST_CASE("Script flush lets active interpreters finish without recaching",
+          "[lua][script-flush]")
+{
+    EloqKV::RedisServiceImpl service("", "test");
+    auto active = service.GetLuaInterpreter();
+    const auto [ok, sha] = active->CreateFunction("return 42");
+    REQUIRE(ok);
+    REQUIRE(service.ScriptFlush());
+    std::string error;
+    REQUIRE(active->CallFunction(sha, &error));
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    active->LuaReplyToRedisReply(&reply);
+    REQUIRE(reply.integer() == 42);
+    service.CleanAndReturnLuaInterpreter(std::move(active));
+
+    auto current = service.GetLuaInterpreter();
+    REQUIRE_FALSE(current->CallFunction(sha, &error));
+    const auto [recompiled, same_sha] = current->CreateFunction("return 42");
+    REQUIRE(recompiled);
+    REQUIRE(same_sha == sha);
+    REQUIRE(current->CallFunction(sha, &error));
+    service.CleanAndReturnLuaInterpreter(std::move(current));
+}
+
+TEST_CASE("Lua reset contains finalizer errors and preserves copied replies",
+          "[lua][memory][finalizer]")
+{
+    const std::string finalizer =
+        GENERATE(std::string("error('gc failure')"),
+                 std::string("redis.call('GET', 'k')"));
+    LuaInterpreter interpreter;
+    std::string value(1024 * 1024, 'v');
+    std::vector<std::string_view> args{value};
+    interpreter.SetGlobalArray("ARGV", args);
+    int hook_calls = 0;
+    auto hook_owner = std::make_shared<int>(1);
+    std::weak_ptr<int> observer = hook_owner;
+    interpreter.SetScriptRedisHook(
+        [hook_owner, &hook_calls](auto *, const auto &, auto *)
+        { ++hook_calls; });
+    hook_owner.reset();
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    Evaluate(interpreter,
+             "collectgarbage('stop'); local p = newproxy(true); "
+             "getmetatable(p).__gc = function() " +
+                 finalizer + " end; return ARGV[1]",
+             reply);
+
+    // The body succeeded. Its finalizer runs only when Reset collects the
+    // completed attempt, after the Redis hook has become invalid.
+    REQUIRE_FALSE(interpreter.Reset());
+    REQUIRE(observer.expired());
+    REQUIRE(hook_calls == 0);
+    REQUIRE(reply.data().as_string() == value);
+    // The failed VM is destroyed at scope exit, rather than reused.
+}
+
+TEST_CASE("Lua pool discards a VM whose reset finalizer failed",
+          "[lua][finalizer]")
+{
+    EloqKV::RedisServiceImpl service("", "test");
+    auto interpreter = service.GetLuaInterpreter();
+    std::string value(1024 * 1024, 'v');
+    std::vector<std::string_view> args{value};
+    interpreter->SetGlobalArray("ARGV", args);
+    const std::string script =
+        "collectgarbage('stop'); local p = newproxy(true); "
+        "getmetatable(p).__gc = function() error('gc failure') end; "
+        "return ARGV[1]";
+    auto [ok, sha] = interpreter->CreateFunction(script);
+    REQUIRE(ok);
+    std::string error;
+    REQUIRE(interpreter->CallFunction(sha, &error));
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    interpreter->LuaReplyToRedisReply(&reply);
+    service.CleanAndReturnLuaInterpreter(std::move(interpreter));
+    REQUIRE(reply.data().as_string() == value);
+
+    auto replacement = service.GetLuaInterpreter();
+    REQUIRE_FALSE(replacement->CallFunction(sha, &error));
+    service.CleanAndReturnLuaInterpreter(std::move(replacement));
+}
+
+TEST_CASE("Closing a Lua VM revokes its Redis hook before finalizers",
+          "[lua][finalizer]")
+{
+    int hook_calls = 0;
+    auto interpreter = std::make_unique<LuaInterpreter>();
+    interpreter->SetScriptRedisHook([&hook_calls](auto *, const auto &, auto *)
+                                    { ++hook_calls; });
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    Evaluate(*interpreter,
+             "collectgarbage('stop'); local p = newproxy(true); "
+             "getmetatable(p).__gc = function() redis.call('GET', 'k') end; "
+             "return 42",
+             reply);
+    // Exercise destruction without Reset, as on direct owner teardown.
+    interpreter.reset();
+    REQUIRE(hook_calls == 0);
+    REQUIRE(reply.integer() == 42);
+}
+
+TEST_CASE("Large Lua arguments are collected after the VM baseline falls",
+          "[lua][memory][finalizer]")
+{
+    LuaInterpreter interpreter;
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    Evaluate(interpreter,
+             "collectgarbage('stop'); local value = string.rep('x', 1048576); "
+             "local p = newproxy(true); getmetatable(p).__gc = function() "
+             "local keep = value end; return #value",
+             reply);
+    REQUIRE(reply.integer() == 1024 * 1024);
+    REQUIRE(interpreter.Reset());
+    // Lua 5.1 retains a finalized userdata and its captured value until a
+    // subsequent collection. One successful full GC is not a zero-garbage
+    // guarantee, and its high-water count must not suppress future cleanup.
+    REQUIRE(MemoryKiB(interpreter) > 1024);
+    Evaluate(interpreter, "collectgarbage('collect'); return 1", reply);
+    REQUIRE(MemoryKiB(interpreter) < 128);
+
+    std::string value(1024 * 1024, 'v');
+    std::vector<std::string_view> args{value};
+    interpreter.SetGlobalArray("ARGV", args);
+    Evaluate(interpreter, "return ARGV[1]", reply);
+    REQUIRE(interpreter.Reset());
+    REQUIRE(MemoryKiB(interpreter) < 128);
+    REQUIRE(reply.data().as_string() == value);
+}
+
+TEST_CASE("Old resolved EVALSHA bodies cannot repopulate a flushed VM pool",
+          "[lua][script-flush]")
+{
+    EloqKV::RedisServiceImpl service("", "test");
+    const std::string old_body = "return 42";
+    butil::Arena arena;
+    brpc::RedisReply loaded(&arena);
+    REQUIRE(service.ScriptLoad({"script", "load", old_body}, &loaded));
+    const std::string old_sha = loaded.data().as_string();
+    // EVALSHA resolved its body in the service's initial generation, but has
+    // not yet checked out a VM. FLUSH wins that interval.
+    const uint64_t resolved_generation = 0;
+    REQUIRE(service.ScriptFlush());
+    auto current = service.GetLuaInterpreter();
+    const auto [ok, current_sha] = current->CreateFunction("return 17");
+    REQUIRE(ok);
+    service.CleanAndReturnLuaInterpreter(std::move(current));
+
+    for (int attempt = 0; attempt < 2; ++attempt)
+    {
+        auto old_request = service.GetLuaInterpreter(resolved_generation);
+        const auto [compiled, sha] = old_request->CreateFunction(old_body);
+        REQUIRE(compiled);
+        REQUIRE(sha == old_sha);
+        std::string error;
+        REQUIRE(old_request->CallFunction(old_sha, &error));
+        brpc::RedisReply reply(&arena);
+        old_request->LuaReplyToRedisReply(&reply);
+        REQUIRE(reply.integer() == 42);
+        service.CleanAndReturnLuaInterpreter(std::move(old_request));
+
+        current = service.GetLuaInterpreter();
+        REQUIRE_FALSE(current->CallFunction(old_sha, &error));
+        REQUIRE(current->CallFunction(current_sha, &error));
+        service.CleanAndReturnLuaInterpreter(std::move(current));
+    }
+    brpc::RedisReply exists(&arena);
+    REQUIRE(service.ScriptExists({"script", "exists", old_sha}, &exists));
+    REQUIRE(exists[0].integer() == 0);
+}
+
+TEST_CASE("Native Lua preparation and reply conversion do not run finalizers",
+          "[lua][finalizer]")
+{
+    LuaInterpreter interpreter;
+    std::string value(1024 * 1024, 'v');
+    std::vector<std::string_view> args{value};
+    interpreter.SetGlobalArray("ARGV", args);
+    int hook_calls = 0;
+    interpreter.SetScriptRedisHook([&hook_calls](auto *, const auto &, auto *)
+                                   { ++hook_calls; });
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    // The proxy remains rooted throughout script execution and reply
+    // conversion, but is no longer reachable once the reply table is popped.
+    Evaluate(interpreter,
+             "local p = newproxy(true); getmetatable(p).__gc = function() "
+             "redis.call('GET', 'k') end; local reply = {ARGV[1]}; "
+             "reply.keep = p; return reply",
+             reply);
+    REQUIRE(hook_calls == 0);
+    interpreter.SetGlobalArray("KEYS", args);
+    REQUIRE(hook_calls == 0);
+    REQUIRE_FALSE(interpreter.Reset());
+    REQUIRE(hook_calls == 0);
+    REQUIRE(reply[0].data().as_string() == value);
+}
+
+TEST_CASE("Script flush contains finalizer errors from idle VMs",
+          "[lua][finalizer][script-flush]")
+{
+    const std::string finalizer =
+        GENERATE(std::string("error('gc failure')"),
+                 std::string("redis.call('GET', 'k')"));
+    EloqKV::RedisServiceImpl service("", "test");
+    auto interpreter = service.GetLuaInterpreter();
+    int hook_calls = 0;
+    interpreter->SetScriptRedisHook([&hook_calls](auto *, const auto &, auto *)
+                                    { ++hook_calls; });
+    const std::string script =
+        "collectgarbage('stop'); local p = newproxy(true); "
+        "getmetatable(p).__gc = function() " +
+        finalizer + " end; return 42";
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    Evaluate(*interpreter, script, reply);
+    REQUIRE(interpreter->Reset());  // Small input does not force a full GC.
+    service.CleanAndReturnLuaInterpreter(std::move(interpreter));
+    REQUIRE(service.ScriptFlush());
+    REQUIRE(hook_calls == 0);
+    REQUIRE(reply.integer() == 42);
+}

--- a/tests/unit/eloq/lua_lifetime_test.cpp
+++ b/tests/unit/eloq/lua_lifetime_test.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "lua_interpreter.h"
+#include "output_handler.h"
 #include "redis_service.h"
 
 extern "C"
@@ -18,6 +19,11 @@ namespace EloqKV
 {
 struct LuaInterpreterTestPeer
 {
+    static lua_State *State(LuaInterpreter &interpreter)
+    {
+        return interpreter.lua_;
+    }
+
     static size_t MemoryBytes(const LuaInterpreter &interpreter)
     {
         return G(interpreter.lua_)->totalbytes;
@@ -34,6 +40,58 @@ namespace
 {
 using EloqKV::LuaInterpreter;
 using EloqKV::LuaInterpreterTestPeer;
+
+class ScopedLuaAllocationFailure
+{
+public:
+    explicit ScopedLuaAllocationFailure(LuaInterpreter &interpreter)
+        : lua_(LuaInterpreterTestPeer::State(interpreter))
+    {
+        original_allocator_ = lua_getallocf(lua_, &original_context_);
+        lua_setallocf(lua_, Allocate, this);
+    }
+
+    ~ScopedLuaAllocationFailure()
+    {
+        lua_setallocf(lua_, original_allocator_, original_context_);
+    }
+
+    void FailNextGrowth(size_t minimum_size)
+    {
+        minimum_size_ = minimum_size;
+        armed_ = true;
+    }
+
+    size_t FailureCount() const
+    {
+        return failures_;
+    }
+
+private:
+    static void *Allocate(void *context,
+                          void *pointer,
+                          size_t old_size,
+                          size_t new_size)
+    {
+        auto *self = static_cast<ScopedLuaAllocationFailure *>(context);
+        if (self->armed_ && new_size > old_size &&
+            new_size >= self->minimum_size_)
+        {
+            self->armed_ = false;
+            ++self->failures_;
+            return nullptr;
+        }
+        return self->original_allocator_(
+            self->original_context_, pointer, old_size, new_size);
+    }
+
+    lua_State *lua_;
+    lua_Alloc original_allocator_;
+    void *original_context_{nullptr};
+    size_t minimum_size_{0};
+    size_t failures_{0};
+    bool armed_{false};
+};
 
 struct ScopedRedisStats
 {
@@ -465,4 +523,60 @@ TEST_CASE("Lua VM retirement preserves client connection counters",
     }
     REQUIRE(EloqKV::RedisStats::GetConnReceivedCount() == 1);
     REQUIRE(EloqKV::RedisStats::GetConnectingCount() == 0);
+}
+
+TEST_CASE(
+    "Lua pool reuse clears a Redis call interrupted by allocation failure",
+    "[lua][memory][redis-call-reuse]")
+{
+    EloqKV::RedisServiceImpl service("", "test");
+    auto interpreter = service.GetLuaInterpreter();
+    LuaInterpreter *original_interpreter = interpreter.get();
+    auto [compiled, sha] =
+        interpreter->CreateFunction("return redis.call('GET', 'k')");
+    REQUIRE(compiled);
+
+    const std::string large_reply(4096, 'r');
+    size_t failed_hook_calls = 0;
+    {
+        // The guard lives outside lua_pcall's frames, so the Lua OOM jump
+        // cannot skip restoration of the VM's allocator.
+        ScopedLuaAllocationFailure allocation_failure(*interpreter);
+        interpreter->SetScriptRedisHook(
+            [&](auto *, const auto &, EloqKV::OutputHandler *output)
+            {
+                ++failed_hook_calls;
+                allocation_failure.FailNextGrowth(large_reply.size());
+                output->OnString(large_reply);
+            });
+        std::string error;
+        const bool success = interpreter->CallFunction(sha, &error);
+        interpreter->SetScriptRedisHook(nullptr);
+        REQUIRE_FALSE(success);
+        REQUIRE(allocation_failure.FailureCount() == 1);
+        REQUIRE(failed_hook_calls == 1);
+        REQUIRE(error.find("not enough memory") != std::string::npos);
+    }
+
+    service.CleanAndReturnLuaInterpreter(std::move(interpreter));
+    interpreter = service.GetLuaInterpreter();
+    REQUIRE(interpreter.get() == original_interpreter);
+
+    size_t recovered_hook_calls = 0;
+    interpreter->SetScriptRedisHook(
+        [&](auto *, const auto &, EloqKV::OutputHandler *output)
+        {
+            ++recovered_hook_calls;
+            output->OnString("recovered");
+        });
+    std::string error;
+    REQUIRE(interpreter->CallFunction(sha, &error));
+    butil::Arena arena;
+    brpc::RedisReply reply(&arena);
+    interpreter->LuaReplyToRedisReply(&reply);
+    INFO((reply.is_error() ? reply.error_message() : "non-error reply"));
+    REQUIRE(recovered_hook_calls == 1);
+    REQUIRE(reply.is_string());
+    REQUIRE(reply.data().as_string() == "recovered");
+    service.CleanAndReturnLuaInterpreter(std::move(interpreter));
 }

--- a/tests/unit/eloq/lua_lifetime_test.cpp
+++ b/tests/unit/eloq/lua_lifetime_test.cpp
@@ -35,6 +35,33 @@ namespace
 using EloqKV::LuaInterpreter;
 using EloqKV::LuaInterpreterTestPeer;
 
+struct ScopedRedisStats
+{
+    ScopedRedisStats()
+    {
+        EloqKV::RedisStats::ExposeBVar();
+    }
+
+    ~ScopedRedisStats()
+    {
+        EloqKV::RedisStats::HideBVar();
+    }
+};
+
+struct ScopedSocket
+{
+    ~ScopedSocket()
+    {
+        if (id != brpc::INVALID_SOCKET_ID)
+        {
+            brpc::Socket::SetFailed(id);
+        }
+    }
+
+    brpc::SocketId id{brpc::INVALID_SOCKET_ID};
+    brpc::SocketUniquePtr socket;
+};
+
 void Evaluate(LuaInterpreter &interpreter,
               std::string_view script,
               brpc::RedisReply &reply)
@@ -400,4 +427,42 @@ TEST_CASE("Script flush contains finalizer errors from idle VMs",
     REQUIRE(service.ScriptFlush());
     REQUIRE(hook_calls == 0);
     REQUIRE(reply.integer() == 42);
+}
+
+TEST_CASE("Lua VM retirement preserves client connection counters",
+          "[lua][script-flush][stats]")
+{
+    ScopedRedisStats stats;
+    ScopedSocket socket;
+    brpc::SocketOptions options;
+    // A real brpc Socket object exercises the client-context constructor,
+    // without opening a network connection or a listening service.
+    REQUIRE(brpc::Socket::Create(options, &socket.id) == 0);
+    REQUIRE(brpc::Socket::Address(socket.id, &socket.socket) == 0);
+    REQUIRE(EloqKV::RedisStats::GetConnectingCount() == 0);
+    {
+        EloqKV::RedisConnectionContext client(socket.socket.get(), nullptr);
+        REQUIRE(EloqKV::RedisStats::GetConnReceivedCount() == 1);
+        REQUIRE(EloqKV::RedisStats::GetConnectingCount() == 1);
+        for (int iteration = 0; iteration < 4; ++iteration)
+        {
+            {
+                EloqKV::RedisServiceImpl service("", "test");
+                auto interpreter = service.GetLuaInterpreter();
+                butil::Arena arena;
+                brpc::RedisReply reply(&arena);
+                Evaluate(*interpreter, "return 42", reply);
+                service.CleanAndReturnLuaInterpreter(std::move(interpreter));
+                REQUIRE(service.ScriptFlush());
+                REQUIRE(EloqKV::RedisStats::GetConnectingCount() == 1);
+                service.CleanAndReturnLuaInterpreter(
+                    service.GetLuaInterpreter());
+            }
+            // Service destruction retires its remaining idle interpreter too.
+            REQUIRE(EloqKV::RedisStats::GetConnReceivedCount() == 1);
+            REQUIRE(EloqKV::RedisStats::GetConnectingCount() == 1);
+        }
+    }
+    REQUIRE(EloqKV::RedisStats::GetConnReceivedCount() == 1);
+    REQUIRE(EloqKV::RedisStats::GetConnectingCount() == 0);
 }


### PR DESCRIPTION
## Context

Idle Lua interpreters retained the last KEYS/ARGV globals, while SCRIPT FLUSH cleared only the service's source map and left compiled functions in the interpreter pool. Clearing the stack did not remove those owners. Returning pooled state also requires guarding finalizers from errors and from calls through an already-completed transaction.

## Behavior before and after

Completed attempts release argument/stack roots, revoke their Redis transaction hook, and clear the active-command guard even when a Lua error bypassed its normal decrement. Large inputs trigger protected collection before reuse. SCRIPT FLUSH destroys idle interpreters and invalidates in-flight interpreters so they cannot return an obsolete compiled cache to the pool. Requests that resolved EVALSHA before FLUSH may finish, including retries, without repopulating the current cache. Internal Lua context destruction does not change real client connection counts.

## Implementation

- Replace stack-only cleanup with a protected Reset that clears roots and the active-command guard, collects large input or significant VM growth, and reports finalizer failure; failed resets discard the VM.
- Use lua_cpcall so cleanup and closure allocation have a Lua error boundary. Automatic GC runs inside protected script execution, and is stopped during native preparation/reply conversion and idle periods. Global-table protections and a disabled transaction hook also apply during cleanup/destruction.
- Coordinate pool checkout/return and SCRIPT FLUSH with the existing script mutex and a generation counter. EVALSHA carries its lookup generation across checkout/retry. Destroy retired VMs outside the mutex.
- Count connection closure only for socket-backed contexts. Update lifecycle documentation and add a dedicated Lua regression target.

## Design decisions and alternatives

Full collection after every small script would repeatedly traverse the compiled cache. Reset collects when input exceeds 64 KiB or owned VM memory has grown by more than 64 KiB since the last complete collection. The separate input counter is necessary because automatic GC can lower current memory beneath an older baseline. This is not an interpreter-count limit or a cap on live compiled scripts.

A bare lua_gc outside protected execution can let a user __gc error reach Lua's panic path. Failed cleanup therefore retires the VM; lua_close already protects finalizer errors, and the transaction hook is revoked before close. Lua can retain some finalized userdata until another cycle and shrinks its shared scratch buffer gradually. The tests distinguish those runtime-owned bytes from the completed call's argument roots rather than equating one GC with zero RSS.

## Test plan

- [x] Current-head focused suite: 14 test cases / 198 assertions
- [x] Current-head Debug build, formatting, and merge-base diff checks
- [ ] Redis server/TCL or HA integration
- [ ] Throughput/latency benchmark

The build uses installed third-party dependencies with S3 data/log backends, ELOQ_MODULE_ENABLED and EXT_TX_PROC_ENABLED. No ASan/UBSan is enabled.

```sh
export PATH=/opt/eloq/third_party/bin:$PATH
export LD_LIBRARY_PATH=/opt/eloq/third_party/lib:/opt/eloq/third_party/lib64
export GLOG_minloglevel=2
cmake -S /tmp/eloq-lua-lifetime-pr.jg79jtqv/src -B /tmp/eloq-lua-lifetime-pr.jg79jtqv/bld -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_WITH_TESTS=ON -DWITH_TESTS=OFF -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 -DWITH_LOG_SERVICE=ON -DEXT_TX_PROC_ENABLED=ON -DELOQ_MODULE_ENABLED=ON -DELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party -DELOQ_THIRD_PARTY_REQUIRED=ON -DCMAKE_INSTALL_PREFIX=/tmp/eloq-lua-lifetime-pr.jg79jtqv/install
cmake --build /tmp/eloq-lua-lifetime-pr.jg79jtqv/bld --target lua_lifetime_test --parallel 2
ctest --test-dir /tmp/eloq-lua-lifetime-pr.jg79jtqv/bld -R '^lua_lifetime_test$' --output-on-failure -V
```

At head `515b3ea`, based on parent `1c02c42` and engine gitlink `5c0be9f`, the existing standard Debug/S3 build rebuilt the changed production and test objects successfully. Verbose CTest passed 1/1, running all 14 Catch cases / 198 assertions. Formatting and merge-base diff checks passed. The test run starts no database or listening service. The prior head `807d0de` also completed its full GitHub CI matrix; checks for this follow-up commit are tracked separately and are not claimed as passed.

The allocation-failure regression uses the real Lua allocator API to reject one growth allocation while `LuaOutputHandler::OnString` copies a 4 KiB Redis reply. After restoring the allocator, it returns the interpreter through the service pool and checks that the same VM successfully executes another `redis.call`. Against the unchanged `807d0de` Reset, the same test fails because the Redis hook is not called and the reply reports a recursive call. The fixed Reset clears the abandoned active-command guard before pool return.

Tests use the real vendored Lua runtime and public interpreter/service paths without starting a database. They cover binary 1 MiB arguments and copied replies, compilation/runtime errors, script-created temporaries, baseline decreases, failing/Redis-calling finalizers, native preparation/reply boundaries, idle/active/lookup-before-checkout flush generations, and real-client versus internal-context connection accounting. A test peer measures Lua-owned bytes and shared scratch without executing another script or triggering GC, and provides the Lua state solely to install the scoped allocation-failure injector; tests never set the active-command guard directly.

## Risk assessment

Collection and VM retirement can shift memory peaks and increase latency for large calls; no workload benchmark was run. A finalizer that never returns still has no execution deadline. Script source/compiled caches remain unbounded between explicit flushes. The cleanup must stay after response conversion or attempt failure, and obsolete generations must never be re-enqueued. The guard reset covers reuse after an attempt ends; recovery inside the same script through Lua pcall/xpcall and general C++ longjmp unwinding remain outside this patch. No WAL, persisted data or RESP-format changes.

## Rollback plan

Revert this PR. No data or configuration migration.

## Reviewer guide

Review ResetLuaState/LuaInterpreter::Reset and the protected CallFunction GC boundary first, then EVALSHA lookup generation, pool checkout/return and ScriptFlush. The lifetime tests exercise both successful reuse and terminal retirement; connection accounting is in RedisConnectionContext's destructor.

## Follow-up work

Full server scripting/HA validation and a workload-level latency benchmark. Interpreter-count/script-cache quotas and finalizer execution limits remain separate work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Lua interpreter cleanup and memory management between script executions.
  - Prevented outdated cached scripts from being reused after `SCRIPT FLUSH`.
  - Improved error-path cleanup, finalizer handling, and recovery after interrupted Redis calls.
  - Corrected connection statistics so internal Lua operations do not inflate closed-connection counts.

- **Documentation**
  - Documented Lua interpreter lifetime, cache-generation handling, cleanup behavior, and safety guarantees.

- **Tests**
  - Added coverage for Lua lifetime, memory cleanup, script flushing, pooling, errors, and connection statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
